### PR TITLE
Fix accountType enum value UNKNOWN

### DIFF
--- a/src/main/avro/ExternalMetric.avsc
+++ b/src/main/avro/ExternalMetric.avsc
@@ -13,9 +13,9 @@
       "type": {
         "name": "AccountType",
         "type": "enum",
-        "default": "UNKOWN",
+        "default": "UNKNOWN",
         "symbols": [
-          "UNKOWN",
+          "UNKNOWN",
           "CORE",
           "ENCORE",
           "RCN"


### PR DESCRIPTION
# What

Fixes a typo with the UNKNOWN entry in the `accountType` enum.

# Why

n/a

# TODO

none