### PR TITLE
Envoy's ID is now passed in gRPC call headers rather than message body

### DIFF
--- a/src/main/proto/telemetry-edge.proto
+++ b/src/main/proto/telemetry-edge.proto
@@ -11,11 +11,9 @@ service TelemetryAmbassador {
 message EnvoySummary {
     string version = 1;
 
-    string instanceId = 2;
+    repeated AgentType supportedAgents = 2;
 
-    repeated AgentType supportedAgents = 3;
-
-    map<string, string> labels = 4;
+    map<string, string> labels = 3;
 }
 
 enum AgentType {
@@ -72,24 +70,22 @@ message ConfigurationOp {
 
 // mainly used to test the ambassador->envoy liveness of the channel, but could eventually
 // contain the full set of instructions of ensure consistency
-message EnvoyInstructionRefresh{}
+message EnvoyInstructionRefresh {}
 
-message KeepAliveRequest{
-    string instanceId = 1;
+message KeepAliveRequest {
 }
-message KeepAliveResponse{}
+
+message KeepAliveResponse {}
 
 message LogEvent {
-    string instanceId = 1;
-    AgentType agentType = 2;
-    string jsonContent = 3;
+    AgentType agentType = 1;
+    string jsonContent = 2;
 }
 
-message PostLogEventResponse{}
+message PostLogEventResponse {}
 
 message PostedMetric {
-    string instanceId = 1;
-    Metric metric = 2;
+    Metric metric = 1;
 }
 
 message Metric {
@@ -107,4 +103,4 @@ message NameTagValueMetric {
     map<string,string> svalues = 5;
 }
 
-message PostMetricResponse{}
+message PostMetricResponse {}

--- a/src/main/proto/telemetry-edge.proto
+++ b/src/main/proto/telemetry-edge.proto
@@ -14,6 +14,8 @@ message EnvoySummary {
     repeated AgentType supportedAgents = 2;
 
     map<string, string> labels = 3;
+
+    string identifier = 4;
 }
 
 enum AgentType {


### PR DESCRIPTION
# Resolves

n/a

# What

Carries over the proto file changes from 
- https://github.com/racker/salus-telemetry-envoy/pull/21
- https://github.com/racker/salus-telemetry-envoy/pull/22

# How

For now we maintain separate copies of the proto file for the Go (Envoy) and Java (Ambassador) code bases, so this PR copies over the same proto content used by the Envoy.

## How to test

With all related PRs can perform manual, integration test with an Envoy connecting to the Ambassador and confirmation of successful keep alives.

# Why

n/a

# TODO

none