### PR TITLE
Add NodeInfo Model

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class NodeInfo {
+    @NotBlank
+    String identifier;
+
+    @NotBlank
+    String identifierValue;
+
+    @NotNull
+    Map<String, String> labels;
+
+    @NotNull
+    String envoyId;
+
+    @NotBlank
+    String host;
+
+    @NotNull
+    int port;
+
+    @NotBlank
+    String tenantId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.net.SocketAddress;
 import java.util.Map;
 
 @Data
@@ -39,11 +40,8 @@ public class NodeInfo {
     String envoyId;
 
     @NotBlank
-    String host;
-
-    @NotNull
-    int port;
+    String tenantId;
 
     @NotBlank
-    String tenantId;
+    SocketAddress address;
 }


### PR DESCRIPTION
# Related PRs
https://github.com/racker/salus-telemetry-etcd-adapater/pull/1
https://github.com/racker/salus-telemetry-ambassador/pull/3
https://github.com/racker/salus-telemetry-model/pull/3

# What
An object to store general info about an envoy.

# Why

This is what will be stored under `/nodes/expected/...` and `/nodes/active/...` for the presence monitoring stuff.