### PR TITLE
Add connection status model

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/NodeConnectionStatus.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/NodeConnectionStatus.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+
+@Data
+public class NodeConnectionStatus {
+    @NotNull
+    Date lastConnectedTime;
+
+    @NotNull
+    boolean isConnected;
+}


### PR DESCRIPTION
# Related PRs
https://github.com/racker/salus-telemetry-etcd-adapter/pull/3

# What

An object to store basic connection info about an envoy.

# Why

Needed somewhere to store this info and it felt like it made more sense to have a new small object rather than letting the existing ones grow.

# TODO

Maybe this is where we store the host/port, rather than in the NodeInfo object.