### PR TITLE
Fix NodeInfo serialization

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/NodeInfo.java
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.util.Map;
 
 @Data
@@ -36,12 +36,12 @@ public class NodeInfo {
     @NotNull
     Map<String, String> labels;
 
-    @NotNull
+    @NotBlank
     String envoyId;
 
     @NotBlank
     String tenantId;
 
-    @NotBlank
-    SocketAddress address;
+    @NotNull
+    InetSocketAddress address;
 }


### PR DESCRIPTION
Cannot use an abstract class in these models.  Casting to `InetSocketAddress` works fine.

Fixed up the annotations as well as they were wrongly swapped for two values.

Other thoughts:
Yesterday I was thinking we might want to create these objects without yet seeing a connection, so I was going to change the address field to `Nullable`, but then that'd mean the envoyId should also be able to be null.  Decided not to do that yet until we know since it'd involve extra validations in other parts of the system.