### PR TITLE
Renaming AgentInfo to AgentRelease to better reflect its purpose

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
@@ -18,35 +18,26 @@
 
 package com.rackspace.salus.telemetry.model;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class AgentInfo {
+public class AgentRelease {
     String id;
 
-    @NotBlank
     String version;
 
-    @NotNull
     AgentType type;
 
-    @NotNull
     OperatingSystem os;
 
-    @NotNull
     Architecture arch;
 
-    @NotBlank
     String url;
 
-    @NotNull
     Checksum checksum;
 
     /**
      * Path to the agent's executable within the package
      */
-    @NotBlank
     String exe;
 }


### PR DESCRIPTION
# Resolves

Part of SALUS-81

# What

While converting public API to GraphQL I wanted to fix the naming of AgentInfo since it didn't clearly reflect what it was meant to convey.

## How to test

Via existing unit tests...after other PRs are done.

# Why

n/a

# TODO

Related PRs for
- [ ] [ambassador](https://github.com/racker/salus-telemetry-ambassador/pull/5)
- [ ] api
- [ ] [etcd-adapter](https://github.com/racker/salus-telemetry-etcd-adapter/pull/7)