### PR TITLE
Rename Node to Resource

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceConnectionStatus.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceConnectionStatus.java
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotNull;
 import java.util.Date;
 
 @Data
-public class NodeConnectionStatus {
+public class ResourceConnectionStatus {
     @NotNull
     Date lastConnectedTime;
 

--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
@@ -26,7 +26,7 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 
 @Data
-public class NodeInfo {
+public class ResourceInfo {
     @NotBlank
     String identifier;
 


### PR DESCRIPTION
Speaking to @itzg he said we should start using Resource instead of Node since that's the term all the other products in the company are starting to use.

Doing this now so I can start using it for my next PRs.