### PR TITLE
Add resource crud functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rackspace.salus</groupId>
@@ -49,6 +49,12 @@
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <version>${javax-validation.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+      <version>2.0.8.RELEASE</version>
+      <scope>compile</scope>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -40,7 +40,7 @@ public class Resource {
     ResourceIdentifier resourceIdentifier;
 
     @ElementCollection
-    @CollectionTable(name="labels", joinColumns = @JoinColumn(name="id"))
+    @CollectionTable(name="resource_labels", joinColumns = @JoinColumn(name="id"))
     @NotNull
     Map<String,String> labels;
 

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -1,0 +1,50 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "resources",
+        uniqueConstraints={@UniqueConstraint(columnNames={"tenant_id","identifier_name","identifier_value"})})
+@Data
+public class Resource {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @Valid
+    ResourceIdentifier resourceIdentifier;
+
+    @ElementCollection
+    @CollectionTable(name="labels", joinColumns = @JoinColumn(name="id"))
+    @NotNull
+    Map<String,String> labels;
+
+    @NotBlank
+    @Column(name="tenant_id")
+    String tenantId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceIdentifier.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceIdentifier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+@Embeddable
+@Data
+public class ResourceIdentifier implements Serializable {
+
+    @NotNull
+    @Column(name="identifier_name")
+    private String identifierName;
+
+    @NotNull
+    @Column(name="identifier_value")
+    private String identifierValue;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.model.Resource;
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface ResourceRepository extends CrudRepository<Resource, Long> {
+}


### PR DESCRIPTION
# What

Adds some new `Resource` Entities and a CRUD Repository.

# Why

Allows us to perform crud operations on these objects.  We can now store them in SQL.

I purposely created a new Resource object to avoid interfering with the ResourceInfo that is currently stored in etcd.  Naming it `Resource` in the long run is probably better anyway.

# Testing
I've been testing manually with the ambassador, but this will be more relevant as we start to create the resource registration service.

When an envoy connects I can see this data:

```
mysql> select * from resources;
+----+-----------------+------------------+-----------+
| id | identifier_name | identifier_value | tenant_id |
+----+-----------------+------------------+-----------+
|  1 | hostname        | MV906GG8WL       | aaaaaa    |
+----+-----------------+------------------+-----------+
1 row in set (0.00 sec)

mysql> select * from labels;
+----+------------+------------+
| id | labels     | labels_key |
+----+------------+------------+
|  1 | DARWIN     | os         |
|  1 | MV906GG8WL | hostname   |
|  1 | X86_64     | arch       |
+----+------------+------------+
3 rows in set (0.00 sec)

```

# TODO

Eventually this repo should only consist of the data stored in SQL.  This gives us a good distinction for what goes in here vs. what might be stored in `etcd-adapter`