### PR TITLE
Add AttachEvent which will be sent over kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,16 @@
   <dependencies>
 
     <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-common</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.16.22</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.github.zafarkhaja</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/events/AttachEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/events/AttachEvent.java
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.model;
+package com.rackspace.salus.telemetry.events;
 
-import lombok.Data;
-
+import com.rackspace.salus.common.messaging.KafkaMessageKey;
+import java.util.Map;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.net.InetSocketAddress;
-import java.util.Map;
+import lombok.Data;
 
+@KafkaMessageKey(properties = {"tenantId", "identifierName", "identifierValue"})
 @Data
 public class AttachEvent {
     @NotBlank
@@ -44,6 +44,11 @@ public class AttachEvent {
     @NotBlank
     String tenantId;
 
+    /**
+     * The remote hostname or IP address of the Envoy's TCP connection to the Ambassador.
+     * Note that this may be a misleading address if any NAT or proxy is used along the path of
+     * the connection.
+     */
     @NotNull
-    InetSocketAddress address;
+    String envoyAddress;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/AttachEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/AttachEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+@Data
+public class AttachEvent {
+    @NotBlank
+    String identifierName;
+
+    @NotBlank
+    String identifierValue;
+
+    @NotEmpty
+    Map<String,String> labels;
+
+    @NotBlank
+    String envoyId;
+
+    @NotBlank
+    String ambassadorId;
+
+    @NotBlank
+    String tenantId;
+
+    @NotNull
+    InetSocketAddress address;
+}


### PR DESCRIPTION
First iteration of the attach event which will be utilized by a few services.

A thought: should we keep the sql specific data in `model` and things that will just be kafka events in a different package?

Also we might want to break away from using `InetSocketAddress`.