### PR TITLE
Removing ambassadorId from AttachEvent

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/events/AttachEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/events/AttachEvent.java
@@ -39,9 +39,6 @@ public class AttachEvent {
     String envoyId;
 
     @NotBlank
-    String ambassadorId;
-
-    @NotBlank
     String tenantId;
 
     /**

--- a/src/main/java/com/rackspace/salus/telemetry/events/lombok.config
+++ b/src/main/java/com/rackspace/salus/telemetry/events/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.accessors.chain = true


### PR DESCRIPTION

# Resolves

Discovered during SALUS-136

# What

Remove the ambassadorId from the AttachEvent since the Ambassador's don't (yet) have an ID concept and there's no immediate need for an Ambassador ID.

Also adds a lombok config to the newly added events package. A new config was added rather than moving the existing one in "model" up a level, since that would have left a lombok config at a very wide package of com.rackspace.salus.telemetry, which is the root package of most of our modules.