### PR TITLE
Exclude sping security and bring in other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,6 @@
       <artifactId>hibernate-jpamodelgen</artifactId>
       <version>5.3.7.Final</version>
     </dependency>
-    <dependency>
-      <groupId>com.rackspace.salus</groupId>
-      <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-common</artifactId>
       <version>0.1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <!-- this app is not intended for external exposure, so excluding default security behaviors -->
+          <artifactId>spring-boot-starter-security</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -68,6 +75,17 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
       <version>2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-jpamodelgen</artifactId>
+      <version>5.3.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-protocol</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Prevents spring security from being pulled in every time this repo is used.

Also pulls in an additional hibernate dependency for some of the stuff that with be coming with the resource management service.