### PR TITLE
Add resource events and set resourceId

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/errors/ResourceAlreadyExists.java
+++ b/src/main/java/com/rackspace/salus/telemetry/errors/ResourceAlreadyExists.java
@@ -16,6 +16,6 @@
 
 package com.rackspace.salus.telemetry.errors;
 
-public class ResourceAlreadyExists extends Exception {
+public class ResourceAlreadyExists extends RuntimeException {
     public ResourceAlreadyExists(String message) { super(message);};
 }

--- a/src/main/java/com/rackspace/salus/telemetry/errors/ResourceAlreadyExists.java
+++ b/src/main/java/com/rackspace/salus/telemetry/errors/ResourceAlreadyExists.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.errors;
+
+public class ResourceAlreadyExists extends Exception {
+    public ResourceAlreadyExists(String message) { super(message);};
+}

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/AttachEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/AttachEvent.java
@@ -18,19 +18,20 @@ package com.rackspace.salus.telemetry.messaging;
 
 import com.rackspace.salus.common.messaging.KafkaMessageKey;
 import java.util.Map;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
+// Using the old validation exceptions for podam support
+// Will move to the newer ones once they're supported.
+//import javax.validation.constraints.NotBlank;
+//import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.NotBlank;
 import lombok.Data;
 
-@KafkaMessageKey(properties = {"tenantId", "identifierName", "identifierValue"})
+@KafkaMessageKey(properties = {"tenantId", "resourceId"})
 @Data
 public class AttachEvent {
     @NotBlank
-    String identifierName;
-
-    @NotBlank
-    String identifierValue;
+    String resourceId;
 
     @NotEmpty
     Map<String,String> labels;

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/OperationType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/OperationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.model;
+package com.rackspace.salus.telemetry.messaging;
 
-import lombok.Data;
-
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.validation.constraints.NotNull;
-import java.io.Serializable;
-
-@Embeddable
-@Data
-public class ResourceIdentifier implements Serializable {
-
-    @NotNull
-    @Column(name="identifier_name")
-    private String identifierName;
-
-    @NotNull
-    @Column(name="identifier_value")
-    private String identifierValue;
+public enum OperationType {
+    CREATE,
+    UPDATE,
+    DELETE
 }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/ResourceEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/ResourceEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.messaging;
+
+import java.util.Map;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import com.rackspace.salus.common.messaging.KafkaMessageKey;
+import com.rackspace.salus.telemetry.model.Resource;
+import lombok.Data;
+
+@KafkaMessageKey(properties = {"tenantId", "operation"})
+@Data
+public class ResourceEvent {
+    @NotBlank
+    Resource resource;
+
+    @NotNull
+    Map<String,String> oldLabels;
+
+    @NotBlank
+    String operation;
+
+    @NotNull
+    boolean presenceMonitorChange;
+
+    @NotBlank
+    String tenantId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/ResourceEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/ResourceEvent.java
@@ -24,7 +24,6 @@ import com.rackspace.salus.common.messaging.KafkaMessageKey;
 import com.rackspace.salus.telemetry.model.Resource;
 import lombok.Data;
 
-@KafkaMessageKey(properties = {"tenantId", "operation"})
 @Data
 public class ResourceEvent {
     @NotBlank
@@ -34,11 +33,8 @@ public class ResourceEvent {
     Map<String,String> oldLabels;
 
     @NotBlank
-    String operation;
+    OperationType operation;
 
     @NotNull
     boolean presenceMonitorChange;
-
-    @NotBlank
-    String tenantId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/EnvoySummary.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/EnvoySummary.java
@@ -34,5 +34,5 @@ public class EnvoySummary {
     @NotEmpty
     Map<String,String> labels;
 
-    String identifierName;
+    String resourceId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -21,23 +21,23 @@ package com.rackspace.salus.telemetry.model;
 import lombok.Data;
 
 import javax.persistence.*;
-import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.util.Map;
-import java.util.UUID;
 
 @Entity
 @Table(name = "resources",
-        uniqueConstraints={@UniqueConstraint(columnNames={"tenant_id","identifier_name","identifier_value"})})
+        uniqueConstraints={@UniqueConstraint(columnNames={"tenant_id","resource_identifier"})})
 @Data
-public class Resource {
+public class Resource implements Serializable {
     @Id
     @GeneratedValue
     Long id;
 
-    @Valid
-    ResourceIdentifier resourceIdentifier;
+    @NotNull
+    @Column(name="resource_id")
+    String resourceId;
 
     @ElementCollection
     @CollectionTable(name="resource_labels", joinColumns = @JoinColumn(name="id"))

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 @Entity
 @Table(name = "resources",
-        uniqueConstraints={@UniqueConstraint(columnNames={"tenant_id","resource_identifier"})})
+        uniqueConstraints={@UniqueConstraint(columnNames={"tenant_id","resource_id"})})
 @Data
 public class Resource implements Serializable {
     @Id

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -47,4 +47,7 @@ public class Resource {
     @NotBlank
     @Column(name="tenant_id")
     String tenantId;
+
+    @NotNull
+    boolean presenceMonitoringEnabled;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -39,9 +39,8 @@ public class Resource implements Serializable {
     @Column(name="resource_id")
     String resourceId;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="resource_labels", joinColumns = @JoinColumn(name="id"))
-    @NotNull
     Map<String,String> labels;
 
     @NotBlank
@@ -49,5 +48,5 @@ public class Resource implements Serializable {
     String tenantId;
 
     @NotNull
-    boolean presenceMonitoringEnabled;
+    Boolean presenceMonitoringEnabled;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
@@ -31,7 +31,6 @@ public class ResourceInfo {
     @NotBlank
     String resourceId;
 
-    @NotEmpty
     Map<String,String> labels;
 
     @NotBlank

--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
@@ -29,10 +29,7 @@ import java.util.Map;
 @Data
 public class ResourceInfo {
     @NotBlank
-    String identifierName;
-
-    @NotBlank
-    String identifierValue;
+    String resourceId;
 
     @NotEmpty
     Map<String,String> labels;

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
@@ -17,8 +17,8 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.model.Resource;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 
-public interface ResourceRepository extends CrudRepository<Resource, Long> {
+public interface ResourceRepository extends PagingAndSortingRepository<Resource, Long> {
 }


### PR DESCRIPTION
# What

It adds the event that will be sent via Kafka whenever a resource change occurs.  Also modifies the existing resource object a little.

We made a decision to use `resourceId` instead of the `identifierName/Value` combo.  This includes those changes.

## How to test

This will be part of the Resource Management service PR.

# Why

The Monitor Management and Presence Monitor services will need to consume these.

# TODO

Finalize interaction between resource management and monitor management.