### PR TITLE
Use hibernate validation for podam support

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Resource.java
@@ -21,7 +21,10 @@ package com.rackspace.salus.telemetry.model;
 import lombok.Data;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotBlank;
+// Using the old validation exceptions for podam support
+// Will move to the newer ones once they're supported.
+//import javax.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Map;

--- a/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ResourceInfo.java
@@ -19,7 +19,6 @@
 package com.rackspace.salus.telemetry.model;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 


### PR DESCRIPTION
This change allows us to use `podam` for these objects in tests.

I've been meaning to try push a PR to podam to support the newer validation methods... will likely look into that over the next week as I'll technically be between sprints.