### PR TITLE
added potential MonitorEvent Data Object

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -1,6 +1,8 @@
 package com.rackspace.salus.telemetry.messaging;
 
 import java.util.Map;
+
+import com.rackspace.salus.telemetry.model.AgentConfig;
 import lombok.Data;
 
 @Data
@@ -9,14 +11,13 @@ public class MonitorEvent {
     String ambassadorId;
     String envoyId;
 
-    //checkData
-    Map<String, String> labels;
-
     //tenantOfEnvoy
     String tenantId;
 
     OperationType operationType;
 
     //Optional: for remote checks
-    String customerTenantTag;
+    String targetTenant;
+
+    AgentConfig config;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -1,0 +1,16 @@
+package com.rackspace.salus.telemetry.messaging;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class MonitorEvent {
+
+    public boolean presenceMonitoringEnabled;
+
+    String tenantId;
+
+    String resourceId;
+
+    public Map<OperationType, Map<String, String>> operationOrganizedLabels;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -15,7 +15,7 @@ public class MonitorEvent {
     //tenantOfEnvoy
     String tenantId;
 
-    String operationType;
+    OperationType operationType;
 
     //Optional: for remote checks
     String customerTenantTag;

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -6,11 +6,17 @@ import lombok.Data;
 @Data
 public class MonitorEvent {
 
-    public boolean presenceMonitoringEnabled;
+    String ambassadorId;
+    String envoyId;
 
+    //checkData
+    Map<String, String> labels;
+
+    //tenantOfEnvoy
     String tenantId;
 
-    String resourceId;
+    String operationType;
 
-    public Map<OperationType, Map<String, String>> operationOrganizedLabels;
+    //Optional: for remote checks
+    String customerTenantTag;
 }


### PR DESCRIPTION
# Resolves

    SALUS-129

# What

    add a sharable data object for MonitorEvents that can also be used in the Ambassador

# How

    I tried to grab what looks like the data that the Ambassador is already grabbing from etcd. 

## How to test

    <instructions for verifying the changes specific to this PR>

# Why

    This data seems similar to the ResourceEvent. Depending on the circumstance we might even be able to use the ResourceEvent. Or just a Resource Object. But the Ambassador code seems to be written to take a list of multiple different OperationTypes.

# TODO

    This is a WIP so I need consensus from someone else at least.