### PR TITLE
Use labels in AgentRelease instead of os and arch fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~    Copyright 2018 Rackspace US, Inc.
+  ~ Copyright 2019 Rackspace US, Inc.
   ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  ~
-  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -80,6 +78,12 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jpamodelgen</artifactId>
       <version>5.3.7.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
@@ -1,23 +1,22 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.model;
 
+import java.util.List;
 import lombok.Data;
 
 @Data
@@ -28,9 +27,10 @@ public class AgentRelease {
 
     AgentType type;
 
-    OperatingSystem os;
-
-    Architecture arch;
+    /**
+     * The labels <code>os</code> and <code>arch</code> are required.
+     */
+    List<Label> labels;
 
     String url;
 

--- a/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/AgentRelease.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.telemetry.model;
 
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 
 @Data
@@ -30,7 +30,7 @@ public class AgentRelease {
     /**
      * The labels <code>os</code> and <code>arch</code> are required.
      */
-    List<Label> labels;
+    Map<String,String> labels;
 
     String url;
 

--- a/src/main/java/com/rackspace/salus/telemetry/model/Architecture.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Architecture.java
@@ -1,24 +1,24 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.model;
 
 public enum Architecture {
     X86,
-    X86_64
+    X86_64;
+
+    public static final String NAME = "arch";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/Label.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Label.java
@@ -1,30 +1,25 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.model;
 
-import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 
 @Data
 public class Label {
-    @NotEmpty
-    final String name;
-    @NotEmpty
-    final String value;
+    String name;
+    String value;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/Label.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Label.java
@@ -16,10 +16,30 @@
 
 package com.rackspace.salus.telemetry.model;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Data;
 
 @Data
 public class Label {
     String name;
     String value;
+
+    public static Map<String, String> convertToMap(List<Label> labels) {
+        if (labels == null) {
+            return null;
+        }
+        return labels.stream()
+            .collect(Collectors.toMap(Label::getName, Label::getValue));
+    }
+
+    public static List<Label> convertToLabelList(Map<String, String> labels) {
+        if (labels == null) {
+            return null;
+        }
+        return labels.entrySet().stream()
+            .map(entry -> new Label().setName(entry.getKey()).setValue(entry.getValue()))
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/OperatingSystem.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/OperatingSystem.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.model;
@@ -21,5 +19,7 @@ package com.rackspace.salus.telemetry.model;
 public enum OperatingSystem {
     LINUX,
     DARWIN,
-    WINDOWS
+    WINDOWS;
+
+    public static final String NAME = "os";
 }

--- a/src/test/java/com/rackspace/salus/telemetry/model/LabelTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/model/LabelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class LabelTest {
+
+  @Test
+  public void convertingLabelListToMap() {
+    List<Label> asList = new ArrayList<>();
+    asList.add(new Label().setName("name1").setValue("value1"));
+    asList.add(new Label().setName("name2").setValue("value2"));
+
+    final Map<String, String> asMap = Label.convertToMap(asList);
+    assertEquals(2, asMap.size());
+    assertEquals("value1", asMap.get("name1"));
+    assertEquals("value2", asMap.get("name2"));
+  }
+
+  @Test
+  public void convertingMapToLabelList() {
+    Map<String, String> asMap = new HashMap<>();
+    asMap.put("name1", "value1");
+    asMap.put("name2", "value2");
+
+    final List<Label> asList = Label.convertToLabelList(asMap);
+    assertEquals(2, asList.size());
+    assertThat(asList, CoreMatchers.hasItems(
+        new Label().setName("name1").setValue("value1"),
+        new Label().setName("name2").setValue("value2")
+    ));
+  }
+}


### PR DESCRIPTION
# Resolves

While working on https://jira.rax.io/browse/SALUS-205

# What

Makes the AgentRelease model more consistent with the Monitor model where os and arch are already labels there and should be treated the same here in AgentRelease.
