### PR TITLE
Add a data type which supports ObjectMapper deserializing of Page

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/PagedContent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/PagedContent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Data;
+
+/**
+ * This data type provides a JSON ObjectMapper deserialization compatible target for content
+ * serialized from {@link org.springframework.data.domain.Page}
+ *
+ * @param <T> the element type of the content
+ */
+@Data
+public class PagedContent<T> {
+
+  List<T> content;
+
+  int number;
+  int totalPages;
+  int totalElements;
+  boolean last;
+  boolean first;
+
+  public <U> PagedContent<U> map(Function<? super T, ? extends U> converter) {
+    final PagedContent<U> converted = new PagedContent<U>()
+        .setFirst(this.first)
+        .setLast(this.last)
+        .setNumber(this.number)
+        .setTotalElements(this.totalElements)
+        .setTotalPages(this.totalPages);
+
+    converted.setContent(
+        this.content.stream()
+            .map(converter)
+            .collect(Collectors.toList())
+    );
+
+    return converted;
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/model/PagedContentTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/model/PagedContentTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class PagedContentTest {
+
+  @Test
+  public void testMapping() {
+    final PagedContent<Integer> original = new PagedContent<Integer>()
+        .setContent(Arrays.asList(1, 3, 5, 7, 9))
+        .setFirst(true)
+        .setLast(false)
+        .setNumber(3)
+        .setTotalElements(300)
+        .setTotalPages(60);
+
+    final PagedContent<String> converted = original.map(integer -> Integer.toString(integer));
+
+    assertEquals(Arrays.asList("1", "3", "5", "7", "9"), converted.getContent());
+    assertTrue(converted.isFirst());
+    assertFalse(converted.isLast());
+    assertEquals(3, converted.getNumber());
+    assertEquals(300, converted.getTotalElements());
+    assertEquals(60, converted.getTotalPages());
+
+  }
+}


### PR DESCRIPTION
# Resolves

Needed for https://jira.rax.io/browse/SALUS-205

# What

The Spring Data `Page` (and its concrete class `PageImpl) that we use for returning our "get range" API methods is not deserializable by Jackson ObjectMapper due to a lack of default constructor:

```
org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class org.springframework.data.domain.Page]; nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.springframework.data.domain.Page` (no Creators, like default construct, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
```

[This SO answer](https://stackoverflow.com/a/52160387/121324) didn't work when eliminating the unused constructor parameters. It probably does work with all the parameters, but since they're discarded it seems like a brute force/ugly way to solve the problem.

# How

...instead, this PR introduces our own, simple data class that encapsulates just the primary fields we need to convey from the `Page` and it is ObjectMapper friendly.

## How to test

A unit test was added.