### PR TITLE
Add monitor ID to MonitorEvent

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -1,6 +1,20 @@
-package com.rackspace.salus.telemetry.messaging;
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.Map;
+package com.rackspace.salus.telemetry.messaging;
 
 import com.rackspace.salus.telemetry.model.AgentConfig;
 import com.rackspace.salus.telemetry.model.Monitor;
@@ -9,6 +23,7 @@ import lombok.Data;
 @Data
 public class MonitorEvent {
 
+    String monitorId;
     String ambassadorId;
     String envoyId;
 
@@ -25,6 +40,7 @@ public class MonitorEvent {
 
     public MonitorEvent setFromMonitor(Monitor monitor) {
         tenantId = monitor.getTenantId();
+        monitorId = monitor.getId().toString();
         if(monitor.getTargetTenant() != null) {
             targetTenant = monitor.getTargetTenant();
         }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorEvent.java
@@ -53,6 +53,9 @@ public class MonitorEvent {
         if(monitor.getLabels() != null) {
             config.setLabels(monitor.getLabels());
         }
+        if (monitor.getAgentType() != null) {
+            config.setAgentType(monitor.getAgentType());
+        }
         return this;
     }
 }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-205

# What

The Ambassador needs the monitor ID in order to tell the Envoy in the config instruction.