### PR TITLE
Changed the enums to be string in the database so that I could use en…

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
@@ -52,11 +52,13 @@ public class Monitor implements Serializable {
 
     @NotNull
     @Column(name="agent_type")
+    @Enumerated(EnumType.STRING)
     AgentType agentType;
 
     @Column(name="target_tenant")
     String targetTenant;
 
     @Column(name="selector_scope")
+    @Enumerated(EnumType.STRING)
     ConfigSelectorScope selectorScope;
 }


### PR DESCRIPTION
# Resolves

    It helps with https://github.com/racker/salus-telemetry-monitor-management/pull/8
    Which entirely depends on whether people are fine with this change. 

# What

    Alters the enum types to be stored in the database as string rather than integers. Both ways are easy for hibernate to turn back into the proper object but as a String we can do EnumType.valueOf(); without having to create our own integer map.

## How to test

    Run the monitoringManagementTest

# Why

    I looked into getting an enum from an integer value. It's doable. I have done similar things in the past. It is just easier to get a string back from the database and turn it into the enum
