### PR TITLE
Declare label namespaces and utility methods for processing those

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
@@ -23,9 +23,9 @@ import org.springframework.util.Assert;
 public class LabelNamespaces {
 
   /**
-   * Scopes the labels that were discovered by an Envoy and reported during attachment
+   * Scopes the labels that were provided by an Envoy during attachment
    */
-  public static final String DISCOVERED = "discovered";
+  public static final String AGENT = "agent";
 
   /**
    * Scopes the tags of the metrics ingested into the Event Engine that were fields originating
@@ -41,7 +41,7 @@ public class LabelNamespaces {
 
   private static final Set<String> ourNamespaces = new HashSet<>();
   static {
-    ourNamespaces.add(DISCOVERED);
+    ourNamespaces.add(AGENT);
     ourNamespaces.add(EVENT_ENGINE_TAGS);
     ourNamespaces.add(MONITORING_SYSTEM_METADATA);
   }

--- a/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.util.Assert;
+
+public class LabelNamespaces {
+
+  /**
+   * Scopes the labels that were discovered by an Envoy and reported during attachment
+   */
+  public static final String DISCOVERED = "discovered";
+
+  /**
+   * Scopes the tags of the metrics ingested into the Event Engine that were fields originating
+   * from top-level system identifiers, such as account and resource ID
+   */
+  public static final String EVENT_ENGINE_TAGS = "system";
+
+  private static final Set<String> ourNamespaces = new HashSet<>();
+  static {
+    ourNamespaces.add(DISCOVERED);
+    ourNamespaces.add(EVENT_ENGINE_TAGS);
+  }
+
+  /**
+   * Applies the given namespace to the label name/key
+   * @param namespace the namespace to apply
+   * @param labelName the label's name
+   * @return the qualified version of the label name
+   */
+  public static String applyNamespace(String namespace, String labelName) {
+    Assert.hasText(namespace, "namespace is required");
+    Assert.hasText(labelName, "labelName is required");
+    return namespace + "." + labelName;
+  }
+
+  /**
+   * Validates that the given user label does not attempt to use one of our namespaces.
+   * @param label the user provided label
+   * @return true if the user label is valid
+   */
+  public static boolean validateUserLabel(String label) {
+    Assert.notNull(label, "label cannot be null");
+    return ourNamespaces.stream()
+        .noneMatch(namespace -> label.startsWith(namespace + "."));
+  }
+
+  private LabelNamespaces() {}
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/LabelNamespaces.java
@@ -33,10 +33,17 @@ public class LabelNamespaces {
    */
   public static final String EVENT_ENGINE_TAGS = "system";
 
+  /**
+   * Scopes the tags of the metrics ingested into the Event Engine that were supplied via the
+   * system metadata.
+   */
+  public static final String MONITORING_SYSTEM_METADATA = "monitoring_system.metadata";
+
   private static final Set<String> ourNamespaces = new HashSet<>();
   static {
     ourNamespaces.add(DISCOVERED);
     ourNamespaces.add(EVENT_ENGINE_TAGS);
+    ourNamespaces.add(MONITORING_SYSTEM_METADATA);
   }
 
   /**

--- a/src/test/java/com/rackspace/salus/telemetry/model/LabelNamespacesTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/model/LabelNamespacesTest.java
@@ -35,7 +35,7 @@ public class LabelNamespacesTest {
   @Test
   public void testValidateUserLabel_invalid() {
     assertThat(
-        LabelNamespaces.validateUserLabel(LabelNamespaces.DISCOVERED + ".os"),
+        LabelNamespaces.validateUserLabel(LabelNamespaces.AGENT + ".os"),
         is(false)
     );
   }

--- a/src/test/java/com/rackspace/salus/telemetry/model/LabelNamespacesTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/model/LabelNamespacesTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class LabelNamespacesTest {
+
+  @Test
+  public void testValidateUserLabel_valid() {
+    assertThat(
+        LabelNamespaces.validateUserLabel("totallyMyCustomLabel"),
+        is(true)
+    );
+  }
+
+  @Test
+  public void testValidateUserLabel_invalid() {
+    assertThat(
+        LabelNamespaces.validateUserLabel(LabelNamespaces.DISCOVERED + ".os"),
+        is(false)
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateUserLabel_null() {
+    LabelNamespaces.validateUserLabel(null);
+  }
+
+  @Test
+  public void testApplyNamespace() {
+    final String result = LabelNamespaces.applyNamespace("ns", "name");
+    assertThat(result, equalTo("ns.name"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testApplyNamespace_badNamespace() {
+    LabelNamespaces.applyNamespace(null, "nmame");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testApplyNamespace_nullLabel() {
+    LabelNamespaces.applyNamespace("ns", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testApplyNamespace_emptyLabel() {
+    LabelNamespaces.applyNamespace("ns", "");
+  }
+}


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-265 and https://jira.rax.io/browse/SALUS-262

# What

Declares constants for our standardized namespaces and a pair of utility methods for validating and applying those.

## How to test

New unit tests have been added