### PR TITLE
Remove jpa model gen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-jpamodelgen</artifactId>
-      <version>5.3.7.Final</version>
-    </dependency>
-    <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-52</artifactId>
       <version>2.4.1</version>


### PR DESCRIPTION
Due to things like this https://github.com/racker/salus-telemetry-monitor-management/pull/24 where we have removed the use of the `Resource_` and `Monitor_` generated classes, we no longer need to import this module and generate those classes.