### PR TITLE
Better define zones field in a monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
@@ -50,7 +50,7 @@ public class Monitor implements Serializable {
     String monitorName;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name="monitor_label_selectors", joinColumns = @JoinColumn(name="id"))
+    @CollectionTable(name="monitor_label_selectors", joinColumns = @JoinColumn(name="monitor_id"))
     Map<String,String> labelSelector;
 
     @NotBlank

--- a/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
@@ -70,5 +70,6 @@ public class Monitor implements Serializable {
     ConfigSelectorScope selectorScope;
 
     @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="id"))
     List<String> zones;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/Monitor.java
@@ -70,6 +70,6 @@ public class Monitor implements Serializable {
     ConfigSelectorScope selectorScope;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="id"))
+    @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="monitor_id"))
     List<String> zones;
 }


### PR DESCRIPTION
I added this while debugging another problem, and although it might not be required, I think it's better to have it than not so that we clearly set the column name.