### PR TITLE
Add shared json views interface

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/View.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/View.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspace.salus.telemetry.model;
+
+public class View {
+  public interface Public {}
+  public interface Internal extends Public {}
+  public interface Admin extends Internal {}
+}


### PR DESCRIPTION
The available view options we can utilize in the apis.

Moving it out of https://github.com/racker/salus-telemetry-monitor-management/pull/36 since it will need to be shared by more apis