### PR TITLE
Change error code for already exist errors

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/errors/AlreadyExistsException.java
+++ b/src/main/java/com/rackspace/salus/telemetry/errors/AlreadyExistsException.java
@@ -16,6 +16,10 @@
 
 package com.rackspace.salus.telemetry.errors;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
 public class AlreadyExistsException extends RuntimeException {
     public AlreadyExistsException(String message) { super(message);};
 }


### PR DESCRIPTION
# What

Changes the error code from 400 to 422 for cases where the object already exists.

# How

Annotations!

## How to test

I'm trying to verify things are good everywhere but IntelliJ isn't picking up this change locally.  Maybe if this is merged it'll see things easier?

# Why

This was decided in https://github.com/racker/salus-telemetry-monitor-management/pull/29.  Since I've removed the Zone/ResourceAlreadyExists exceptions, I'm moving this error over to this generic error.

> After reading up I'm going with 422 Unprocessable Entity - https://tools.ietf.org/html/rfc4918#section-11.2
> 
> I was starting to lean that way and then read. Since we like to use github as a good example, I'll stick with it.
> 
> > For the record, 422 is also the status code GitHub uses when you try to create a repository by a name already in use.