### PR TITLE
Add entities/repositories from other services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,17 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <version>7.2.1.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -103,6 +114,9 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@NamedQueries({
+    // NOTE this cannot be a repository method since the query needs to select a resulting
+    // type is not an immediate projected field of the repository's entity type
+    @NamedQuery(name = "findBoundAgentTypesByResource",
+      query = "select distinct b.agentInstall.agentRelease.type from BoundAgentInstall b"
+      + " where b.agentInstall.tenantId = :tenantId"
+      + "  and b.resourceId = :resourceId")
+})
+@Table(name = "agent_installs",
+  indexes = {
+    @Index(name = "by_tenant", columnList = "tenantId")
+  }
+)
+@Data
+public class AgentInstall {
+
+  private static final String LABEL_DELIM = "=";
+
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @Column(nullable = false)
+  String tenantId;
+
+  @ManyToOne(optional = false)
+  AgentRelease agentRelease;
+
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name="agent_install_label_selectors", joinColumns = @JoinColumn(name="agent_install_id"))
+  Map<String,String> labelSelector;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/AgentRelease.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/AgentRelease.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "agent_releases",
+  indexes = {
+    @Index(name = "by_type", columnList = "type")
+  }
+)
+@Data
+public class AgentRelease {
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  AgentType type;
+
+  @Column(nullable = false)
+  String version;
+
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(
+      name = "agent_release_labels",
+      joinColumns = @JoinColumn(name = "agent_release_id")
+  )
+  Map<String,String> labels;
+
+  @Column(nullable = false)
+  String url;
+
+  @Column(nullable = false)
+  String exe;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundAgentInstall.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundAgentInstall.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Data;
+
+@Entity
+@IdClass(BoundAgentInstall.PrimaryKey.class)
+@Table(name = "bound_agent_installs")
+@Data
+public class BoundAgentInstall {
+
+  @Data
+  public static class PrimaryKey implements Serializable {
+
+    @org.hibernate.annotations.Type(type = "uuid-char")
+    UUID agentInstall;
+    String resourceId;
+  }
+
+  @Id
+  @ManyToOne
+  AgentInstall agentInstall;
+
+  @Id
+  String resourceId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Index;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+// Using the old validation exceptions for podam support
+// Will move to the newer ones once they're supported.
+//import javax.validation.constraints.NotBlank;
+
+/**
+ * This entity tracks the three-way binding of
+ * <ul>
+ *   <li>monitor</li>
+ *   <li>resource</li>
+ *   <li>zone (empty string for local/agent monitors)</li>
+ * </ul>
+ *
+ * <p>
+ * As part of the binding, the agent configuration content of the monitor is stored in its
+ * rendered form with all context placeholders replaced with their per-binding values.
+ * </p>
+ *
+ * <p>
+ *   This entity has a corresponding DTO at
+ *   {@link com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO}
+ *   where the fields of that class must be maintained to align with the fields of this entity.
+ * </p>
+ */
+@Entity
+@IdClass(BoundMonitor.PrimaryKey.class)
+@Table(name = "bound_monitors",
+indexes = {
+    @Index(name = "by_envoy_id", columnList = "envoyId"),
+    @Index(name = "by_zone_envoy", columnList = "zoneName,envoyId"),
+    @Index(name = "by_resource", columnList = "resourceId")
+})
+@Data
+public class BoundMonitor implements Serializable {
+
+  @Data
+  public static class PrimaryKey implements Serializable {
+
+    /**
+     * The Java and Hibernate type of <code>monitor</code> needs to match the primary key
+     * of {@link Monitor}
+     */
+    @org.hibernate.annotations.Type(type="uuid-char")
+    UUID monitor;
+    String resourceId;
+    String zoneName;
+
+    // resourceTenant does not need to be part of the primary key
+    // since the Monitor, via monitorId, already scopes this binding to a tenant
+  }
+
+  @Id
+  @ManyToOne
+  Monitor monitor;
+
+  /**
+   * For remote monitors, contains the binding of a specific monitoring zone.
+   * For local monitors, this field is an empty string.
+   */
+  @Id
+  @NotNull
+  @Column(length = 100)
+  String zoneName;
+
+  /**
+   * Contains the binding of the {@link Monitor} (via <code>monitorId</code>) to a specific
+   * resource to be monitored.
+   */
+  @Id
+  @NotNull
+  @Column(length = 100)
+  String resourceId;
+
+  @Lob
+  String renderedContent;
+
+  @Column(length = 100)
+  String envoyId;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.validator.constraints.NotBlank;
+
+@Entity
+@Table(name = "monitors", indexes = {
+    @Index(name = "by_tenant", columnList = "tenant_id")
+})
+@NamedQueries({
+    @NamedQuery(name = "Monitor.getDistinctLabelSelectors",
+        query = "select distinct entry(m.labelSelector) from Monitor m where m.tenantId = :tenantId")
+})
+@Data
+public class Monitor implements Serializable {
+    @Id
+    @GeneratedValue
+    @org.hibernate.annotations.Type(type="uuid-char")
+    UUID id;
+
+    @Column(name="monitor_name")
+    String monitorName;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name="monitor_label_selectors", joinColumns = @JoinColumn(name="monitor_id"))
+    Map<String,String> labelSelector;
+
+    @NotBlank
+    @Column(name="tenant_id")
+    String tenantId;
+
+    @NotBlank
+    String content;
+
+    @NotNull
+    @Column(name="agent_type")
+    @Enumerated(EnumType.STRING)
+    AgentType agentType;
+
+    @Column(name="selector_scope")
+    @Enumerated(EnumType.STRING)
+    ConfigSelectorScope selectorScope;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="monitor_id"))
+    List<String> zones;
+
+    @CreationTimestamp
+    @Column(name="created_timestamp")
+    Instant createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name="updated_timestamp")
+    Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.validator.constraints.NotBlank;
+
+@Entity
+@Table(name = "policy_monitors")
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MonitorPolicy extends Policy {
+
+  @NotBlank
+  @Column(name="name")
+  String name;
+
+  @NotBlank
+  @Column(name="monitor_id")
+  String monitorId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Policy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Policy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "policies")
+@Inheritance(
+    strategy = InheritanceType.JOINED
+)
+@Data
+public abstract class Policy implements Serializable {
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name="scope")
+  PolicyScope scope;
+
+  @Column(name="subscope")
+  String subscope;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.ValidLabelKeys;
+import com.vladmihalcea.hibernate.type.json.JsonStringType;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Map;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.validator.constraints.NotBlank;
+
+// Using the old validation exceptions for podam support
+// Will move to the newer ones once they're supported.
+//import javax.validation.constraints.NotBlank;
+
+@Entity
+@Table(name = "resources",
+    uniqueConstraints = {
+        // also enables indexed query by tenant ID
+        @UniqueConstraint(columnNames = {"tenant_id", "resource_id"})
+    })
+@NamedQueries({
+    @NamedQuery(name = "Resource.getDistinctLabels",
+    query = "select distinct entry(r.labels) from Resource r where r.tenantId = :tenantId"),
+    @NamedQuery(name = "Resource.getMetadata",
+    query = "select r.metadata from Resource r where r.tenantId = :tenantId"),
+    @NamedQuery(name = "Resource.getAllDistinctTenants",
+    query = "select distinct r.tenantId from Resource r")
+})
+@TypeDef(name = "json", typeClass = JsonStringType.class)
+@Data
+public class Resource implements Serializable {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    /**
+     * This will typically be something like CORE device ID or Xen ID for public cloud VMs.
+     * This must be unique for a given tenant.
+     */
+    @NotNull
+    @Column(name="resource_id")
+    String resourceId;
+
+    /**
+     * Labels are an indexed and query'able aspect of resources that are used for monitor
+     * matching.
+     */
+    @ValidLabelKeys
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name="resource_labels",
+        joinColumns = @JoinColumn(name="id"),
+        indexes = {
+            @Index(columnList = "id,labels_key,labels")
+        }
+    )
+    Map<String,String> labels;
+
+    /**
+     * Unlike labels, metadata is not indexed and not used for resource/monitor matching.
+     */
+    @Type(type = "json")
+    @Column(columnDefinition = "text")
+    Map<String,String> metadata;
+
+    @NotBlank
+    @Column(name="tenant_id")
+    String tenantId;
+
+    @NotNull
+    Boolean presenceMonitoringEnabled;
+
+    String region;
+
+    /**
+     * Indicates if this resource is or ever was associated with an Envoy.
+     */
+    boolean associatedWithEnvoy;
+
+    @CreationTimestamp
+    @Column(name="created_timestamp")
+    Instant createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name="updated_timestamp")
+    Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.vladmihalcea.hibernate.type.json.JsonStringType;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.validator.constraints.NotBlank;
+
+@Entity
+@Table(name = "tenant_metadata", indexes = {
+    @Index(name = "by_tenant", columnList = "tenant_id"),
+    @Index(name = "by_account_type", columnList = "account_type")
+})
+@NamedQueries({
+    @NamedQuery(name = "TenantMetadata.getByAccountType",
+        query = "select distinct t.tenantId from TenantMetadata t where t.accountType = :accountType")
+})
+@TypeDef(name = "json", typeClass = JsonStringType.class)
+@Data
+public class TenantMetadata {
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @NotBlank
+  @Column(name = "tenant_id", unique = true)
+  String tenantId;
+
+  @Column(name = "account_type")
+  String accountType;
+
+  @NotNull
+  @Type(type = "json")
+  @Column(columnDefinition = "text")
+  Map<String, String> metadata;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Zone.java
@@ -40,6 +40,9 @@ import java.util.UUID;
 
 @Data
 public class Zone implements Serializable {
+
+  public static final String PUBLIC = "_PUBLIC_";
+
   @Id
   @GeneratedValue
   @Type(type="uuid-char")

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Zone.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.ZoneState;
+import java.time.Instant;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.boot.convert.DurationUnit;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "zones", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"tenant_id", "name"})})
+
+@Data
+public class Zone implements Serializable {
+  @Id
+  @GeneratedValue
+  @Type(type="uuid-char")
+  UUID id;
+
+  /**
+   * Contains the tenant that owns the private zone or "_PUBLIC_" for public zones.
+   */
+  @NotBlank
+  @Column(name="tenant_id")
+  String tenantId;
+
+  /**
+   * Contains the unique name/label for the zone.
+   * Public zones should have a "public/" prefix and then a trailing region descriptor.
+   * e.g. "public/us-central-1"
+   */
+  @NotBlank
+  @Column(name="name")
+  String name;
+
+  /**
+   * Contains an optional hosting provider of the zone.
+   * e.g. Rackspace, Google, Amazon
+   */
+  @Column(name="provider")
+  String provider;
+
+  /**
+   * Contains an optional region to more precisely define where the zone is running.
+   * e.g. for Rackspace, dfw3 may be used; for Google, europe-west3.
+   */
+  @Column(name="provider_region")
+  String providerRegion;
+
+  /**
+   * Defines whether a zone is public or private.
+   */
+  @NotNull
+  @Column(name="is_public")
+  boolean isPublic;
+
+  /**
+   * Contains an optional list of ipv4 and ipv6 ranges that the pollers in this zone reside in.
+   * This can be used to whitelist ranges to allow for remote polling.
+   * Entries must be valid CIDR notation.
+   */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @Column(name="source_ips")
+  List<String> sourceIpAddresses;
+
+  /**
+   * Defines whether the zone is available or not.
+   * This helps determine whether new monitors can be added to the zone.
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name="state")
+  ZoneState state;
+
+  /**
+   * Contains a timeout value which begins to countdown after a poller has disconnected.
+   * If the timeout is met, the monitors bound to it will be distributed to other available pollers.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  @Column(name="poller_timeout")
+  Duration pollerTimeout = Duration.ofSeconds(120);
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/PolicyScope.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/PolicyScope.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum PolicyScope {
+  GLOBAL (0),
+  ACCOUNT_TYPE (1),
+  SLA (2),
+  TENANT (3);
+
+  private final int priority;
+  PolicyScope(int priority) {
+    this.priority = priority;
+  }
+
+  public int getPriority() {
+    return this.priority;
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/ZoneState.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ZoneState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspace.salus.telemetry.model;
+
+public enum ZoneState {
+    ACTIVE, // running and accepting new checks
+    INACTIVE, // not running
+    MAINTENANCE // running but not accepting new checks
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/AgentInstallRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/AgentInstallRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.AgentInstall;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AgentInstallRepository extends CrudRepository<AgentInstall, UUID> {
+
+  Optional<AgentInstall> findByIdAndTenantId(UUID id, String tenantId);
+
+  Page<AgentInstall> findAllByTenantId(String tenantId, Pageable pageable);
+
+  List<AgentInstall> findAllByTenantIdAndAgentRelease_Id(String tenantId, UUID agentReleaseId);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/AgentReleaseRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/AgentReleaseRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.AgentRelease;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AgentReleaseRepository extends CrudRepository<AgentRelease, UUID> {
+
+  List<AgentRelease> findAllByTypeAndVersion(AgentType agentType, String version);
+
+  Page<AgentRelease> findAll(Pageable pageable);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundAgentInstallRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundAgentInstallRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.BoundAgentInstall;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BoundAgentInstallRepository extends CrudRepository<BoundAgentInstall, BoundAgentInstall.PrimaryKey> {
+
+  @Query("from BoundAgentInstall b"
+      + " where b.agentInstall.tenantId = :tenantId"
+      + "  and b.resourceId = :resourceId"
+      + "  and b.agentInstall.agentRelease.type = :agentType")
+  List<BoundAgentInstall> findAllByTenantResourceAgentType(
+      String tenantId,
+      String resourceId,
+      AgentType agentType
+  );
+
+  @Query("from BoundAgentInstall b"
+      + " where b.agentInstall.tenantId = :tenantId"
+      + "  and b.resourceId = :resourceId")
+  List<BoundAgentInstall> findAllByTenantResource(
+      String tenantId,
+      String resourceId
+  );
+
+  List<BoundAgentInstall> findAllByAgentInstall_Id(UUID agentInstallId);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, BoundMonitor.PrimaryKey> {
+
+  List<BoundMonitor> findAllByEnvoyId(String envoyId);
+  Page<BoundMonitor> findAllByEnvoyId(String envoyId, Pageable page);
+
+  @Query("select b from BoundMonitor b where b.zoneName = :zoneName and b.envoyId is null")
+  List<BoundMonitor> findAllWithoutEnvoyInPublicZone(String zoneName);
+
+  @Query(
+      "select b from BoundMonitor b"
+      + " where b.monitor.tenantId = :tenantId"
+          + " and b.zoneName = :zoneName"
+          + " and b.envoyId is null")
+  List<BoundMonitor> findAllWithoutEnvoyInPrivateZone(String tenantId, String zoneName);
+
+  /**
+   * Queries for all of the bound monitors assigned to the given envoy in a public zone.
+   * @param zoneName name of the public zone
+   * @param envoyId the envoy ID
+   * @param pageable if non-null, applies paging limits on the query
+   * @return bound monitors assigned to envoy in zone
+   */
+  @Query("select b from BoundMonitor b where b.zoneName = :zoneName and b.envoyId = :envoyId")
+  List<BoundMonitor> findWithEnvoyInPublicZone(String zoneName, String envoyId, Pageable pageable);
+
+  /**
+   * Queries for all of the bound monitors assigned to the given envoy in a private zone.
+   * @param tenantId the tenant owning the private zone
+   * @param zoneName name of the private zone
+   * @param envoyId the envoy ID
+   * @param pageable if non-null, applies paging limits on the query
+   * @return bound monitors assigned to envoy in zone
+   */
+  @Query("select b from BoundMonitor b"
+      + " where b.monitor.tenantId = :tenantId"
+      + " and b.zoneName = :zoneName"
+      + " and b.envoyId = :envoyId")
+  List<BoundMonitor> findWithEnvoyInPrivateZone(String tenantId, String zoneName, String envoyId,
+                                                Pageable pageable);
+
+  @Query("select distinct b.resourceId from BoundMonitor b where b.monitor.id = :monitorId")
+  Set<String> findResourceIdsBoundToMonitor(UUID monitorId);
+
+  @Query("select distinct b.monitor.id from BoundMonitor b"
+      + " where b.resourceId = :resourceId"
+      + " and b.monitor.tenantId = :tenantId")
+  List<UUID> findMonitorsBoundToResource(String tenantId, String resourceId);
+
+  List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
+
+  List<BoundMonitor> findAllByMonitor_TenantId(String tenantId);
+  Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable page);
+
+  @Query("select b from BoundMonitor b"
+      + " where b.monitor.tenantId = :tenantId"
+      + "  and b.resourceId = :resourceId"
+      + "  and b.monitor.selectorScope = 'LOCAL'")
+  List<BoundMonitor> findAllLocalByTenantResource(String tenantId, String resourceId);
+
+  List<BoundMonitor> findAllByMonitor_Id(UUID monitorId);
+
+  List<BoundMonitor> findAllByMonitor_IdIn(Collection<UUID> monitorIds);
+
+  List<BoundMonitor> findAllByMonitor_IdAndResourceIdIn(UUID monitorId, Collection<String> resourceIds);
+
+  List<BoundMonitor> findAllByMonitor_IdAndZoneNameIn(UUID monitorId, Collection<String> zoneNames);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.entities.MonitorPolicy;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface MonitorPolicyRepository extends PagingAndSortingRepository<MonitorPolicy, UUID> {
+
+  boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.Monitor;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface MonitorRepository extends PagingAndSortingRepository<Monitor, UUID> {
+
+    Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
+
+    @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
+    Page<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone, Pageable page);
+
+    @Query("select count(m) from Monitor m where :zone member of m.zones")
+    int countAllByZonesContains(String zone);
+
+    @Query("select count(m) from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
+    int countAllByTenantIdAndZonesContains(String tenantId, String zone);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/PolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/PolicyRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.Policy;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface PolicyRepository extends PagingAndSortingRepository<Policy, UUID> {
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.Resource;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+
+public interface ResourceRepository extends PagingAndSortingRepository<Resource, Long> {
+
+  List<Resource> findAllByTenantId(String tenantId);
+
+  boolean existsByTenantIdAndResourceId(String tenantId, String resourceId);
+
+  List<Resource> findAllByPresenceMonitoringEnabled(boolean value);
+
+  Page<Resource> findAllByTenantId(String tenantId, Pageable pageable);
+
+  Optional<Resource> findByTenantIdAndResourceId(String tenantId, String resourceId);
+
+  List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.TenantMetadata;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface TenantMetadataRepository extends PagingAndSortingRepository<TenantMetadata, UUID> {
+  Optional<TenantMetadata> findByTenantId(String tenantId);
+}
+

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ZoneRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ZoneRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.Zone;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ZoneRepository extends PagingAndSortingRepository<Zone, UUID> {
+    Optional<Zone> findByTenantIdAndName(String tenantId, String name);
+
+    Page<Zone> findAllByTenantId(String tenantId, Pageable page);
+
+    @Query(
+        "select z from Zone z where z.tenantId = :tenantId"
+        + " or z.tenantId = com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC"
+            + " order by FIELD(tenantId, com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC) DESC"
+            + ", name ASC")
+    Page<Zone> findAllAvailableForTenant(String tenantId, Pageable page);
+
+    boolean existsByTenantIdAndName(String tenantId, String name);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ZoneRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ZoneRepository.java
@@ -31,8 +31,8 @@ public interface ZoneRepository extends PagingAndSortingRepository<Zone, UUID> {
 
     @Query(
         "select z from Zone z where z.tenantId = :tenantId"
-        + " or z.tenantId = com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC"
-            + " order by FIELD(tenantId, com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC) DESC"
+        + " or z.tenantId = com.rackspace.salus.telemetry.entities.Zone.PUBLIC"
+            + " order by FIELD(tenantId, com.rackspace.salus.telemetry.entities.Zone.PUBLIC) DESC"
             + ", name ASC")
     Page<Zone> findAllAvailableForTenant(String tenantId, Pageable page);
 

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundAgentInstallRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundAgentInstallRepositoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.telemetry.entities.AgentInstall;
+import com.rackspace.salus.telemetry.entities.AgentRelease;
+import com.rackspace.salus.telemetry.entities.BoundAgentInstall;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class BoundAgentInstallRepositoryTest {
+
+  @Configuration
+  @EntityScan("com.rackspace.salus.telemetry.entities")
+  @EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
+  static class TestConfiguration {
+  }
+
+  @Autowired
+  BoundAgentInstallRepository repository;
+
+  @Autowired
+  TestEntityManager em;
+
+  @Test
+  public void findAllByTenantResourceAgentType() {
+    final AgentRelease release = saveRelease("1.0.0", AgentType.TELEGRAF);
+
+    final AgentInstall install = saveInstall(release, Collections.singletonMap("os","linux"));
+
+    final BoundAgentInstall binding1 = saveBinding(install, "r-1");
+    // extra entry to verify filtering
+    saveBinding(install, "r-2");
+
+    final List<BoundAgentInstall> results = repository
+        .findAllByTenantResourceAgentType("t-1", "r-1", AgentType.TELEGRAF);
+
+    assertThat(results).containsExactlyInAnyOrder(
+        binding1
+    );
+  }
+
+  @Test
+  public void testFindAllByTenantResource() {
+    final AgentRelease releaseT = saveRelease("1.0.0", AgentType.TELEGRAF);
+    final AgentRelease releaseF = saveRelease("1.1.1", AgentType.FILEBEAT);
+
+    final AgentInstall installT = saveInstall(
+        releaseT, Collections.singletonMap("os", "linux"));
+    final AgentInstall installF = saveInstall(
+        releaseF, Collections.singletonMap("os", "linux"));
+
+    saveBinding(installT, "r-both");
+    saveBinding(installF, "r-both");
+
+    saveBinding(installT, "r-one");
+
+    {
+      final List<BoundAgentInstall> bindings = repository
+          .findAllByTenantResource("t-1", "r-both");
+
+      assertThat(bindings).containsExactlyInAnyOrder(
+          new BoundAgentInstall().setAgentInstall(installT).setResourceId("r-both"),
+          new BoundAgentInstall().setAgentInstall(installF).setResourceId("r-both")
+      );
+    }
+
+    {
+      final List<BoundAgentInstall> bindings = repository
+          .findAllByTenantResource("t-1", "r-one");
+
+      assertThat(bindings).containsExactlyInAnyOrder(
+          new BoundAgentInstall().setAgentInstall(installT).setResourceId("r-one")
+      );
+    }
+
+    {
+      final List<BoundAgentInstall> bindings = repository
+          .findAllByTenantResource("t-1", "r-none");
+
+      assertThat(bindings).isEmpty();
+    }
+
+    {
+      final List<BoundAgentInstall> bindings = repository
+          .findAllByTenantResource("t-other", "r-both");
+
+      assertThat(bindings).isEmpty();
+    }
+  }
+
+  private AgentRelease saveRelease(String version, AgentType agentType) {
+    return em.persistAndFlush(
+          new AgentRelease()
+              .setType(agentType)
+              .setVersion(version)
+              .setUrl("")
+              .setExe("")
+      );
+  }
+
+  private BoundAgentInstall saveBinding(AgentInstall agentInstall, String resourceId) {
+    return em.persistAndFlush(
+          new BoundAgentInstall()
+              .setAgentInstall(agentInstall)
+              .setResourceId(resourceId)
+      );
+  }
+
+  private AgentInstall saveInstall(AgentRelease agentRelease, Map<String, String> installSelector) {
+    return em.persistAndFlush(
+          new AgentInstall()
+              .setAgentRelease(agentRelease)
+              .setTenantId("t-1")
+              .setLabelSelector(installSelector)
+      );
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@AutoConfigureJson
+public class BoundMonitorRepositoryTest {
+
+  @Configuration
+  @EntityScan("com.rackspace.salus.telemetry.entities")
+  @EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
+  static class TestConfiguration {
+  }
+
+  private static final String MONITOR_TENANT = "monitor-t-1";
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private BoundMonitorRepository repository;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Test
+  public void testFindOnesWithoutEnvoy() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", null);
+    save(monitor, "z-1", "r-2", "e-1");
+    save(monitor, "public/1", "r-3", null);
+    save(monitor, "public/1", "r-4", "e-2");
+
+    final List<BoundMonitor> t1z1 = repository.findAllWithoutEnvoyInPrivateZone(MONITOR_TENANT, "z-1");
+    assertThat(t1z1, hasSize(1));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+
+    final List<BoundMonitor> publicResults = repository.findAllWithoutEnvoyInPublicZone("public/1");
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-3"));
+  }
+
+  @Test
+  public void testFindOnesWithEnvoy() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", null);
+    save(monitor, "z-1", "r-2", "e-1");
+    save(monitor, "z-1", "r-3", "e-1");
+    save(monitor, "public/1", "r-4", null);
+    save(monitor, "public/1", "r-5", "e-1");
+    save(monitor, "public/2", "r-6", "e-1");
+
+    final List<BoundMonitor> t1z1 = repository.findWithEnvoyInPrivateZone(
+        MONITOR_TENANT, "z-1", "e-1", null);
+    assertThat(t1z1, hasSize(2));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-2"));
+    assertThat(t1z1.get(1).getResourceId(), equalTo("r-3"));
+
+    final List<BoundMonitor> publicResults = repository.findWithEnvoyInPublicZone("public/1", "e-1", null);
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-5"));
+  }
+
+  @Test
+  public void testFindOnesWithEnvoy_paging() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-1", "r-2", "e-1");
+    save(monitor, "z-1", "r-3", "e-1");
+    save(monitor, "public/1", "r-4", "e-1");
+    save(monitor, "public/1", "r-5", "e-1");
+    save(monitor, "public/1", "r-6", "e-1");
+
+    final List<BoundMonitor> t1z1 = repository.findWithEnvoyInPrivateZone(
+        MONITOR_TENANT, "z-1", "e-1", PageRequest.of(0, 2));
+    assertThat(t1z1, hasSize(2));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+    assertThat(t1z1.get(1).getResourceId(), equalTo("r-2"));
+
+    final List<BoundMonitor> publicResults = repository.findWithEnvoyInPublicZone(
+        "public/1", "e-1", PageRequest.of(0, 2));
+    assertThat(publicResults, hasSize(2));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-4"));
+    assertThat(publicResults.get(1).getResourceId(), equalTo("r-5"));
+  }
+
+  private void save(Monitor monitor, String zone, String resource, String envoyId) {
+    final Monitor retrievedMonitor = entityManager.find(Monitor.class, monitor.getId());
+    assertThat(retrievedMonitor, notNullValue());
+
+    entityManager.persist(new BoundMonitor()
+        .setMonitor(monitor)
+        .setZoneName(zone)
+        .setResourceId(resource)
+        .setEnvoyId(envoyId)
+    );
+    entityManager.flush();
+  }
+
+  @Test
+  public void testFindAllByMonitor_TenantId() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+    final Monitor otherMonitor = createMonitor("t-some-other", ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", null);
+    save(monitor, "z-1", "r-2", "e-1");
+    save(otherMonitor, "public/1", "r-2", null);
+    save(monitor, "z-1", "r-3", "e-1");
+    save(monitor, "public/1", "r-4", null);
+    save(monitor, "public/1", "r-5", "e-1");
+    save(monitor, "public/2", "r-6", "e-1");
+
+    final Page<BoundMonitor> results = repository
+        .findAllByMonitor_TenantId(MONITOR_TENANT, PageRequest.of(1, 2));
+
+    assertThat(results.getContent(), hasSize(2));
+    assertThat(results.getContent().get(0).getResourceId(), equalTo("r-3"));
+    assertThat(results.getContent().get(1).getResourceId(), equalTo("r-4"));
+    assertThat(results.getTotalElements(), equalTo(6L));
+  }
+
+  @Test
+  public void testfindAllByMonitor_IdIn() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+    final Monitor otherMonitor = createMonitor("t-some-other", ConfigSelectorScope.LOCAL);
+    final Monitor yetAnotherMonitor = createMonitor("t-yet-another", ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", null);
+    save(monitor, "z-1", "r-2", null);
+    save(otherMonitor, "public/1", "r-3", null);
+    save(monitor, "z-1", "r-4", null);
+    save(yetAnotherMonitor, "z-1", "r-5", null);
+
+    // EXECUTE
+
+    final List<BoundMonitor> results = repository
+        .findAllByMonitor_IdIn(Arrays.asList(monitor.getId(), otherMonitor.getId()));
+
+    // VERIFY
+
+    assertThat(results, hasSize(4));
+    assertThat(results.get(0).getResourceId(), equalTo("r-1"));
+    assertThat(results.get(1).getResourceId(), equalTo("r-2"));
+    assertThat(results.get(2).getResourceId(), equalTo("r-3"));
+    assertThat(results.get(3).getResourceId(), equalTo("r-4"));
+  }
+
+  @Test
+  public void testfindAllByMonitor_IdAndResourceIdIn() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+    final Monitor otherMonitor = createMonitor("t-some-other", ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-2", "r-1", "e-1");
+    save(otherMonitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-1", "r-2", "e-1");
+    save(otherMonitor, "z-1", "r-2", "e-1");
+    save(monitor, "z-1", "r-3", "e-1");
+    save(otherMonitor, "z-1", "r-3", "e-1");
+
+    final List<BoundMonitor> results = repository
+        .findAllByMonitor_IdAndResourceIdIn(monitor.getId(), Arrays.asList("r-1", "r-3"));
+
+    assertThat(results, hasSize(3));
+    org.assertj.core.api.Assertions.assertThat(results)
+        .usingElementComparatorIgnoringFields("createdTimestamp", "updatedTimestamp")
+        .containsExactlyInAnyOrder(
+          new BoundMonitor()
+              .setMonitor(monitor)
+              .setResourceId("r-1")
+              .setEnvoyId("e-1")
+              .setZoneName("z-1"),
+          new BoundMonitor()
+              .setMonitor(monitor)
+              .setResourceId("r-1")
+              .setEnvoyId("e-1")
+              .setZoneName("z-2"),
+          new BoundMonitor()
+              .setMonitor(monitor)
+              .setResourceId("r-3")
+              .setEnvoyId("e-1")
+              .setZoneName("z-1")
+    );
+  }
+
+  @Test
+  public void testfindAllByMonitor_IdAndZoneIdIn() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+    final Monitor otherMonitor = createMonitor("t-some-other", ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-2", "r-1", "e-1");
+    save(otherMonitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-1", "r-2", "e-1");
+    save(otherMonitor, "z-1", "r-2", "e-1");
+    save(monitor, "z-3", "r-3", "e-1");
+    save(otherMonitor, "z-3", "r-3", "e-1");
+
+    final List<BoundMonitor> results = repository
+        .findAllByMonitor_IdAndZoneNameIn(monitor.getId(), Arrays.asList("z-1", "z-2"));
+
+    assertThat(results, hasSize(3));
+    org.assertj.core.api.Assertions.assertThat(results)
+        .usingElementComparatorIgnoringFields("createdTimestamp", "updatedTimestamp")
+        .containsExactlyInAnyOrder(
+            new BoundMonitor()
+                .setMonitor(monitor)
+                .setResourceId("r-1")
+                .setEnvoyId("e-1")
+                .setZoneName("z-1"),
+            new BoundMonitor()
+                .setMonitor(monitor)
+                .setResourceId("r-1")
+                .setEnvoyId("e-1")
+                .setZoneName("z-2"),
+            new BoundMonitor()
+                .setMonitor(monitor)
+                .setResourceId("r-2")
+                .setEnvoyId("e-1")
+                .setZoneName("z-1")
+        );
+  }
+
+  @Test
+  public void testfindResourceIdsBoundToMonitor() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+    final Monitor otherMonitor = createMonitor("t-some-other", ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-2", "r-1", "e-1");
+    save(otherMonitor, "z-1", "r-3", "e-1");
+    save(monitor, "z-1", "r-2", "e-1");
+
+    final Set<String> resourceIds =
+        repository.findResourceIdsBoundToMonitor(monitor.getId());
+
+    assertThat(resourceIds, containsInAnyOrder("r-1", "r-2"));
+  }
+
+  @Test
+  public void testFindMonitorsBoundToResource() {
+
+    final List<Monitor> monitors = new ArrayList<>();
+    for (int tenantIndex = 0; tenantIndex < 2; tenantIndex++) {
+      for (int monitorIndex = 0; monitorIndex < 5; monitorIndex++) {
+        final Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+        monitor.setId(null);
+        monitor.setTenantId(String.format("t-%d", tenantIndex));
+        final Monitor savedMonitor = entityManager.persistFlushFind(monitor);
+        monitors.add(savedMonitor);
+
+        for (int boundIndex = 0; boundIndex < 3; boundIndex++) {
+          entityManager.persist(
+              new BoundMonitor()
+                  .setMonitor(savedMonitor)
+                  .setZoneName(String.format("z-%d", boundIndex))
+                  .setResourceId("r-1")
+                  .setRenderedContent(monitor.getContent())
+          );
+        }
+      }
+    }
+
+    final List<UUID> monitorIds = repository
+        .findMonitorsBoundToResource("t-0", "r-1");
+
+    assertThat(monitorIds, hasSize(5));
+
+    assertThat(monitorIds, containsInAnyOrder(
+        monitors.get(0).getId(),
+        monitors.get(1).getId(),
+        monitors.get(2).getId(),
+        monitors.get(3).getId(),
+        monitors.get(4).getId()
+    ));
+  }
+
+  @Test
+  public void testfindAllLocalByTenantResource() {
+    final Monitor localMonitorT1 = createMonitor("t-1", ConfigSelectorScope.LOCAL);
+    final Monitor remoteMonitorT1 = createMonitor("t-1", ConfigSelectorScope.REMOTE);
+    final Monitor localMonitorT2 = createMonitor("t-2", ConfigSelectorScope.LOCAL);
+
+    // matches the query of t-1, r-1, local
+    entityManager.persist(
+        new BoundMonitor()
+          .setMonitor(localMonitorT1)
+          .setResourceId("r-1")
+          .setZoneName("")
+          .setRenderedContent("1")
+    );
+    entityManager.persist(
+        new BoundMonitor()
+          .setMonitor(localMonitorT1)
+          .setResourceId("r-2") // mismatch, other resource
+          .setZoneName("")
+          .setRenderedContent("2")
+    );
+    entityManager.persist(
+        new BoundMonitor()
+          .setMonitor(remoteMonitorT1) // mismatch, remote
+          .setResourceId("r-1")
+          .setZoneName("public/west")
+          .setRenderedContent("3")
+    );
+    entityManager.persist(
+        new BoundMonitor()
+          .setMonitor(localMonitorT2) // mismatch, other tenant
+          .setResourceId("r-1")
+          .setZoneName("")
+          .setRenderedContent("4")
+    );
+
+    final List<BoundMonitor> results = repository
+        .findAllLocalByTenantResource("t-1", "r-1");
+
+    assertThat(results, hasSize(1));
+    assertThat(results.get(0).getRenderedContent(), equalTo("1"));
+  }
+
+  private Monitor createMonitor(String monitorTenant,
+                                ConfigSelectorScope selectorScope) {
+    return entityManager.persist(new Monitor()
+        .setAgentType(AgentType.TELEGRAF)
+        .setSelectorScope(selectorScope)
+        .setContent("{}")
+        .setTenantId(monitorTenant)
+    );
+  }
+}


### PR DESCRIPTION
This can be reviewed one commit at a time.

# What

Used in combination with:

https://github.com/racker/salus-policy-management/pull/4
https://github.com/racker/salus-telemetry-monitor-management/pull/68
https://github.com/racker/salus-telemetry-resource-management/pull/48
https://github.com/racker/salus-telemetry-agent-catalog-management/pull/5

We moved the entities/repositories from those repos to here so they can be shared across services.

One thing I had to do was duplicate the `ResolvedZone.PUBLIC` field we use elsewhere within the `Zone` object so we didnt have to make `model` depend on `etcd-adapter`.  we may want to refactor that field out of etcd-adapter later on.

## How to test

Run tests.

# Why

Rather than having our services perform api calls to communicate with eachother they will just read from the shared database. This lowers the risk of hitting circular dependency problems and should reduce latency.

# TODO

Do all the other services.