### PR TITLE
Update entities to work with policy management

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
@@ -31,6 +31,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.validator.constraints.NotBlank;
 
 // Using the old validation exceptions for podam support
 // Will move to the newer ones once they're supported.
@@ -59,9 +60,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @IdClass(BoundMonitor.PrimaryKey.class)
 @Table(name = "bound_monitors",
 indexes = {
-    @Index(name = "by_envoy_id", columnList = "envoyId"),
-    @Index(name = "by_zone_envoy", columnList = "zoneName,envoyId"),
-    @Index(name = "by_resource", columnList = "resourceId")
+    @Index(name = "by_envoy_id", columnList = "envoy_id"),
+    @Index(name = "by_zone_envoy", columnList = "zone_name,envoy_id"),
+    @Index(name = "by_resource", columnList = "resource_id")
 })
 @Data
 public class BoundMonitor implements Serializable {
@@ -75,16 +76,18 @@ public class BoundMonitor implements Serializable {
      */
     @org.hibernate.annotations.Type(type="uuid-char")
     UUID monitor;
+    String tenantId;
     String resourceId;
     String zoneName;
-
-    // resourceTenant does not need to be part of the primary key
-    // since the Monitor, via monitorId, already scopes this binding to a tenant
   }
 
   @Id
   @ManyToOne
   Monitor monitor;
+
+  @NotBlank
+  @Column(name="tenant_id")
+  String tenantId;
 
   /**
    * For remote monitors, contains the binding of a specific monitoring zone.
@@ -92,7 +95,7 @@ public class BoundMonitor implements Serializable {
    */
   @Id
   @NotNull
-  @Column(length = 100)
+  @Column(name="zone_name", length = 100)
   String zoneName;
 
   /**
@@ -101,13 +104,14 @@ public class BoundMonitor implements Serializable {
    */
   @Id
   @NotNull
-  @Column(length = 100)
+  @Column(name="resource_id", length = 100)
   String resourceId;
 
   @Lob
+  @Column(name="rendered_content")
   String renderedContent;
 
-  @Column(length = 100)
+  @Column(name="envoy_id", length = 100)
   String envoyId;
 
   @CreationTimestamp

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -45,8 +45,7 @@ import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "monitors", indexes = {
-    @Index(name = "monitors_by_tenant", columnList = "tenant_id"),
-    @Index(name = "by_tenant_and_resource", columnList = "tenant_id, resource_id")
+    @Index(name = "monitors_by_tenant_and_resource", columnList = "tenant_id, resource_id")
 })
 @NamedQueries({
     @NamedQuery(name = "Monitor.getDistinctLabelSelectors",

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -53,6 +53,9 @@ import org.hibernate.validator.constraints.NotBlank;
 })
 @Data
 public class Monitor implements Serializable {
+
+    public static final String POLICY_TENANT = "_POLICY_";
+
     @Id
     @GeneratedValue
     @org.hibernate.annotations.Type(type="uuid-char")

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -45,7 +45,7 @@ import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "monitors", indexes = {
-    @Index(name = "by_tenant", columnList = "tenant_id")
+    @Index(name = "monitors_by_tenant", columnList = "tenant_id")
 })
 @NamedQueries({
     @NamedQuery(name = "Monitor.getDistinctLabelSelectors",

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
-@Table(name = "policy_monitors")
+@Table(name = "monitor_policies")
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class MonitorPolicy extends Policy {

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
@@ -16,9 +16,11 @@
 
 package com.rackspace.salus.telemetry.entities;
 
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
@@ -33,7 +35,8 @@ public class MonitorPolicy extends Policy {
   @Column(name="name")
   String name;
 
-  @NotBlank
+  @NotNull
   @Column(name="monitor_id")
-  String monitorId;
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID monitorId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
@@ -94,7 +94,7 @@ public class Resource implements Serializable {
      * Unlike labels, metadata is not indexed and not used for resource/monitor matching.
      */
     @Type(type = "json")
-    @Column(columnDefinition = "text")
+        @Column(columnDefinition = "text")
     Map<String,String> metadata;
 
     @NotBlank

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorPolicyEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MonitorPolicyEvent.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.messaging;
 
 import com.rackspace.salus.common.messaging.KafkaMessageKey;
+import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -24,5 +25,5 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @KafkaMessageKey(properties = {"policyId", "tenantId"})
 public class MonitorPolicyEvent extends PolicyEvent {
-  String monitorId;
+  UUID monitorId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/PolicyMonitorUpdateEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/PolicyMonitorUpdateEvent.java
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.repositories;
+package com.rackspace.salus.telemetry.messaging;
 
-import com.rackspace.salus.telemetry.model.PolicyScope;
-import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import java.util.Optional;
+import com.rackspace.salus.common.messaging.KafkaMessageKey;
 import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import lombok.Data;
 
-public interface MonitorPolicyRepository extends PagingAndSortingRepository<MonitorPolicy, UUID> {
-
-  boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
-
-  boolean existsByMonitorId(UUID monitorId);
-
-  Optional<MonitorPolicy> findByMonitorId(UUID monitorId);
-
+@Data
+@KafkaMessageKey(properties = {"tenantId", "monitorId"})
+public class PolicyMonitorUpdateEvent {
+  String tenantId;
+  UUID monitorId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/TenantChangeEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/TenantChangeEvent.java
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.repositories;
+package com.rackspace.salus.telemetry.messaging;
 
-import com.rackspace.salus.telemetry.model.PolicyScope;
-import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import java.util.Optional;
-import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import com.rackspace.salus.common.messaging.KafkaMessageKey;
+import lombok.Data;
 
-public interface MonitorPolicyRepository extends PagingAndSortingRepository<MonitorPolicy, UUID> {
-
-  boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
-
-  boolean existsByMonitorId(UUID monitorId);
-
-  Optional<MonitorPolicy> findByMonitorId(UUID monitorId);
-
+@Data
+@KafkaMessageKey(properties = {"tenantId"})
+public class TenantChangeEvent {
+  String tenantId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/TenantPolicyChangeEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/TenantPolicyChangeEvent.java
@@ -19,8 +19,12 @@ package com.rackspace.salus.telemetry.messaging;
 import com.rackspace.salus.common.messaging.KafkaMessageKey;
 import lombok.Data;
 
+/**
+ * Indicates details relating to a tenant have changed,
+ * which could impact the policies applied to it.
+ */
 @Data
 @KafkaMessageKey(properties = {"tenantId"})
-public class TenantChangeEvent {
+public class TenantPolicyChangeEvent {
   String tenantId;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -85,6 +85,12 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
   List<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant);
   Page<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant, Pageable page);
 
+  List<BoundMonitor> findAllByTenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds);
+  Page<BoundMonitor> findAllByTenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds, Pageable page);
+
+  List<BoundMonitor> findAllByMonitor_TenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds);
+  Page<BoundMonitor> findAllByMonitor_TenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds, Pageable page);
+
   @Query("select b from BoundMonitor b"
       + " where b.monitor.tenantId = :tenantId"
       + "  and b.resourceId = :resourceId"

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -76,8 +76,14 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 
+  List<BoundMonitor> findAllByTenantId(String tenantId);
+  Page<BoundMonitor> findAllByTenantId(String tenantId, Pageable page);
+
   List<BoundMonitor> findAllByMonitor_TenantId(String tenantId);
   Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable page);
+
+  List<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant);
+  Page<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant, Pageable page);
 
   @Query("select b from BoundMonitor b"
       + " where b.monitor.tenantId = :tenantId"

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
@@ -25,4 +25,6 @@ public interface MonitorPolicyRepository extends PagingAndSortingRepository<Moni
 
   boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
 
+  boolean existsByMonitorId(UUID monitorId);
+
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -29,6 +29,8 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     boolean existsByIdAndTenantId(UUID id, String tenantId);
 
+    List<Monitor> findByIdIn(List<UUID> ids);
+
     Optional<Monitor> findByIdAndTenantId(UUID id, String tenantId);
 
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface MonitorRepository extends PagingAndSortingRepository<Monitor, UUID> {
+
+    boolean existsByIdAndTenantId(UUID id, String tenantId);
+
+    Optional<Monitor> findByIdAndTenantId(UUID id, String tenantId);
 
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 


### PR DESCRIPTION
# What

Updates some things which will be needed to complete policy management functionality.

# How

 * Adds column names to entities that didn't have it to make index definitions more clear
 * Add tenantId to boundMonitor
   * On the DTOs this will replace resourceTenant
 * Moved POLICY_TENANT to the entity so it can be shared across repos.
 * Changed monitorId to a UUID to be consistent with the id field of the Monitor entity.
 * Adds some new repository methods
 * Adds PolicyMonitorUpdateEvent
 * Adds TenantChangeEvent

# Why

Bound Monitors must now have tenantId in their primary key since policy monitors will be shared across all tenants.  The previous key is no longer guaranteed to be unique if multiple tenants have the same resource ids.

PolicyMonitorUpdateEvent will be consumed by both policy mgmt and mon mgmt when a policy monitor is updated.  Policy mgmt will receive the event with a null tenantId, then determine which tenants it is relevant to and send out individual event for each of them which mon mgmt will consume and handle.

TenantChangeEvent will be consumed by mon mgmt to ensure all policy monitors are applied correctly.  e.g. the tenant's account type could be updated which should trigger a refresh of what policies are applied to it.

