### PR TITLE
Add label selector method to Monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.entities;
 
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
@@ -67,6 +68,11 @@ public class Monitor implements Serializable {
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="monitor_label_selectors", joinColumns = @JoinColumn(name="monitor_id"))
     Map<String,String> labelSelector;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name="label_selector_method")
+    LabelSelectorMethod labelSelectorMethod = LabelSelectorMethod.AND;
 
     @NotBlank
     @Column(name="tenant_id")

--- a/src/main/java/com/rackspace/salus/telemetry/model/LabelSelectorMethod.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/LabelSelectorMethod.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum LabelSelectorMethod {
+  AND,
+  OR
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/LabelSelectorMethod.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/LabelSelectorMethod.java
@@ -16,6 +16,16 @@
 
 package com.rackspace.salus.telemetry.model;
 
+/**
+ * This defines the operation to be used when performing label matching queries for
+ * objects with a labelSelector field.
+ *
+ * For example, a method of AND on a Monitor means that all the labels on the Monitor must
+ * be found on the Resource for the monitor to be applied.
+ * A method of OR on a Monitor means that at least one of the labels on the Monitor must
+ * be found on the Resource for the monitor to be applied.
+ *
+ */
 public enum LabelSelectorMethod {
   AND,
   OR


### PR DESCRIPTION
# What

Adds a new field `labelSelectorMethod` to the `Monitor` class.

# How

Created an Enum with fields `AND` and `OR`, which are the only available options for now.

## How to test

Run tests in all repos.

# Why

This adds more flexibility to the Monitor configurations and allows for scenarios such as

```
monitorType: SSH
labelSelector: [{"os":"linux"}, {"agent_discovered_os": "linux"}]
labelSelectorMethod: OR
```

With this an SSH monitor will be applied to resources whether there is a user (or automation) specified label on the resource, or if there is an OS label discovered by the envoy that matches.


# TODO

* Adam is updating the sql query that does label matching.
* Monitor Mgmt's policy resource matching will be updated too.