### PR TITLE
Add initial changes for policy metadata

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Entity
+@Table(name = "metadata_policies")
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MetadataPolicy extends Policy {
+
+  public static final String PREFIX = "rackspace.metadata.";
+
+  /**
+   * If left blank, this will apply to all monitor types.
+   * Otherwise the value should match the plugin type provided when a monitor is created.
+   * e.g. ping, http_response, x509_cert, etc.
+   */
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name="monitor_type")
+  MonitorType monitorType;
+
+  /**
+   * All values are stored as strings, so a type must also be stored
+   * so the consumers of these policies know what it should be converted to.
+   */
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name="value_type")
+  MetadataValueType valueType;
+
+  /**
+   * The key does not include the prefix of "rackspace.metadata."
+   */
+  @NotBlank
+  @Column(name="key")
+  String key;
+
+  @NotBlank
+  @Column(name="value")
+  String value;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
@@ -41,7 +41,6 @@ public class MetadataPolicy extends Policy {
    * Otherwise the value should match the plugin type provided when a monitor is created.
    * e.g. ping, http_response, x509_cert, etc.
    */
-  @NotNull
   @Enumerated(EnumType.STRING)
   @Column(name="monitor_type")
   MonitorType monitorType;

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -88,6 +88,7 @@ public class Monitor implements Serializable {
 
     @NotNull
     @Column(name="monitor_type")
+    @Enumerated(EnumType.STRING)
     MonitorType monitorType;
 
     @NotNull

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -97,6 +97,11 @@ public class Monitor implements Serializable {
     @Column(name="resource_id")
     String resourceId;
 
+    @ElementCollection
+    @CollectionTable(name="monitor_template_variables", joinColumns = @JoinColumn(name="monitor_id"),
+        indexes = @Index(name = "monitors_by_template_variable", columnList = "monitor_id"))
+    List<String> templateVariables;
+
     @CreationTimestamp
     @Column(name="created_timestamp")
     Instant createdTimestamp;

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.entities;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
@@ -51,7 +52,10 @@ import org.hibernate.validator.constraints.NotBlank;
 })
 @NamedQueries({
     @NamedQuery(name = "Monitor.getDistinctLabelSelectors",
-        query = "select distinct entry(m.labelSelector) from Monitor m where m.tenantId = :tenantId")
+        query = "select distinct entry(m.labelSelector) from Monitor m where m.tenantId = :tenantId"),
+    @NamedQuery(name = "Monitor.getTenantsUsingTemplateVariable",
+        query = "select distinct m.tenantId from Monitor m join m.templateVariables "
+            + "where :variable member of m.templateVariables")
 })
 @Data
 public class Monitor implements Serializable {
@@ -81,6 +85,10 @@ public class Monitor implements Serializable {
 
     @NotBlank
     String content;
+
+    @NotNull
+    @Column(name="monitor_type")
+    MonitorType monitorType;
 
     @NotNull
     @Column(name="agent_type")

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorMetadataPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorMetadataPolicy.java
@@ -16,47 +16,27 @@
 
 package com.rackspace.salus.telemetry.entities;
 
-import com.rackspace.salus.telemetry.model.MetadataValueType;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import com.rackspace.salus.telemetry.model.TargetClassName;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity
-@Table(name = "metadata_policies")
+@Table(name = "monitor_metadata_policies")
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class MetadataPolicy extends Policy {
-
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  @Column(name="target_class_name")
-  TargetClassName targetClassName;
+public class MonitorMetadataPolicy extends MetadataPolicy {
 
   /**
-   * All values are stored as strings, so a type must also be stored
-   * so the consumers of these policies know what it should be converted to.
+   * If left blank, this will apply to all monitor types.
+   * Otherwise the value should match the plugin type provided when a monitor is created.
+   * e.g. ping, http_response, x509_cert, etc.
    */
-  @NotNull
   @Enumerated(EnumType.STRING)
-  @Column(name="value_type")
-  MetadataValueType valueType;
-
-  /**
-   * The key does not include the prefix of "rackspace.metadata."
-   */
-  @NotBlank
-  @Column(name="metadata_key")
-  String key;
-
-  @NotBlank
-  @Column(name="metadata_value")
-  String value;
+  @Column(name="monitor_type")
+  MonitorType monitorType;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
@@ -38,7 +38,7 @@ import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "tenant_metadata", indexes = {
-    @Index(name = "by_tenant", columnList = "tenant_id"),
+    @Index(name = "metadata_by_tenant", columnList = "tenant_id"),
     @Index(name = "by_account_type", columnList = "account_type")
 })
 @NamedQueries({

--- a/src/main/java/com/rackspace/salus/telemetry/messaging/MetadataPolicyEvent.java
+++ b/src/main/java/com/rackspace/salus/telemetry/messaging/MetadataPolicyEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.messaging;
+
+import com.rackspace.salus.common.messaging.KafkaMessageKey;
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@KafkaMessageKey(properties = {"policyId", "tenantId"})
+public class MetadataPolicyEvent extends PolicyEvent {
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/MetadataField.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MetadataField.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.repositories;
+package com.rackspace.salus.telemetry.model;
 
-import com.rackspace.salus.telemetry.entities.MetadataPolicy;
-import com.rackspace.salus.telemetry.model.PolicyScope;
-import com.rackspace.salus.telemetry.model.TargetClassName;
-import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface MetadataPolicyRepository extends PagingAndSortingRepository<MetadataPolicy, UUID> {
-
-  boolean existsByScopeAndSubscopeAndTargetClassNameAndKey(
-      PolicyScope policyScope, String subscope, TargetClassName className, String key);
-
+/**
+ * This annotation helps identify which fields can be replaced by default policy metadata values.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MetadataField {
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
@@ -19,5 +19,6 @@ package com.rackspace.salus.telemetry.model;
 public enum MetadataValueType {
   DURATION,
   STRING,
+  STRING_LIST,
   INT
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum MetadataValueType {
+  DURATION,
+  STRING,
+  INT
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum MonitorType {
+  ping,
+  http_response,
+  net_response,
+  x509_cert,
+  cpu,
+  disk,
+  diskio,
+  mem,
+  net,
+  procstat
+}

--- a/src/main/java/com/rackspace/salus/telemetry/model/TargetClassName.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/TargetClassName.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum TargetClassName {
+  LocalPlugin,
+  RemotePlugin,
+  Monitor;
+
+  public static TargetClassName getTargetClassName(Object object) {
+    TargetClassName className;
+    try {
+      className = TargetClassName.valueOf(object.getClass().getSimpleName());
+    } catch (IllegalArgumentException e) {
+      try {
+        className = TargetClassName.valueOf(object.getClass().getSuperclass().getSimpleName());
+      } catch (IllegalArgumentException e1) {
+        throw new IllegalStateException(
+            String.format("%s and %s are not a valid TargetClassNames",
+                object.getClass().getSimpleName(),
+                object.getClass().getSuperclass().getSimpleName()));
+      }
+    }
+    return className;
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -76,6 +76,8 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 
+  List<BoundMonitor> findAllByMonitor_IdAndMonitor_TenantId(UUID monitorId, String tenantId);
+
   List<BoundMonitor> findAllByTenantId(String tenantId);
   Page<BoundMonitor> findAllByTenantId(String tenantId, Pageable page);
 

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MetadataPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MetadataPolicyRepository.java
@@ -17,12 +17,14 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface MetadataPolicyRepository extends PagingAndSortingRepository<MetadataPolicy, UUID> {
 
-  boolean existsByScopeAndSubscopeAndKey(PolicyScope policyScope, String subscope, String key);
+  boolean existsByScopeAndSubscopeAndMonitorTypeAndKey(
+      PolicyScope policyScope, String subscope, MonitorType type, String key);
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MetadataPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MetadataPolicyRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.repositories;
+
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface MetadataPolicyRepository extends PagingAndSortingRepository<MetadataPolicy, UUID> {
+
+  boolean existsByScopeAndSubscopeAndKey(PolicyScope policyScope, String subscope, String key);
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorMetadataPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorMetadataPolicyRepository.java
@@ -17,14 +17,16 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface MetadataPolicyRepository extends PagingAndSortingRepository<MetadataPolicy, UUID> {
+public interface MonitorMetadataPolicyRepository extends PagingAndSortingRepository<MonitorMetadataPolicy, UUID> {
 
-  boolean existsByScopeAndSubscopeAndTargetClassNameAndKey(
-      PolicyScope policyScope, String subscope, TargetClassName className, String key);
+  boolean existsByScopeAndSubscopeAndTargetClassNameAndMonitorTypeAndKey(
+      PolicyScope policyScope, String subscope, TargetClassName className, MonitorType type, String key);
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.Optional;
 import java.util.List;
 import java.util.Set;
@@ -40,8 +41,21 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     List<Monitor> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
-    @Query("select m from Monitor m join fetch m.templateVariables where :variable member of m.templateVariables")
-    Set<Monitor> findByTemplateVariablesContaining(String variable);
+    @Query("select m from Monitor m join fetch m.monitorMetadataFields where m.tenantId = :tenantId "
+        + "and :variable member of m.monitorMetadataFields")
+    Set<Monitor> findByTenantIdAndMonitorMetadataFieldsContaining(String tenantId, String variable);
+
+    @Query("select m from Monitor m join fetch m.pluginMetadataFields where m.tenantId = :tenantId "
+        + "and :variable member of m.pluginMetadataFields")
+    Set<Monitor> findByTenantIdAndPluginMetadataFieldsContaining(String tenantId, String variable);
+
+    @Query("select m from Monitor m join fetch m.monitorMetadataFields where m.tenantId = :tenantId "
+        + "and m.monitorType = :type and :variable member of m.monitorMetadataFields")
+    Set<Monitor> findByTenantIdAndMonitorTypeAndMonitorMetadataFieldsContaining(String tenantId, MonitorType type, String variable);
+
+    @Query("select m from Monitor m join fetch m.pluginMetadataFields where m.tenantId = :tenantId "
+        + "and m.monitorType = :type and :variable member of m.pluginMetadataFields")
+    Set<Monitor> findByTenantIdAndMonitorTypeAndPluginMetadataFieldsContaining(String tenantId, MonitorType type, String variable);
 
     @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
     Page<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone, Pageable page);

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.repositories;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import java.util.Optional;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +39,9 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 
     List<Monitor> findByTenantIdAndResourceId(String tenantId, String resourceId);
+
+    @Query("select m from Monitor m join fetch m.templateVariables where :variable member of m.templateVariables")
+    Set<Monitor> findByTemplateVariablesContaining(String variable);
 
     @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
     Page<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone, Pageable page);

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
@@ -27,6 +27,7 @@ import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -421,6 +422,7 @@ public class BoundMonitorRepositoryTest {
         .setContent("{}")
         .setTenantId(monitorTenant)
         .setMonitorType(MonitorType.http_response)
+        .setInterval(Duration.ofSeconds(60))
     );
   }
 }


### PR DESCRIPTION
# What

See title.

# How

`Monitor` was updated to handle the changes in https://github.com/racker/salus-telemetry-monitor-management/pull/80.

The `join fetch` in the `MonitorRepository` is needed since the template variables are lazily fetched, meaning they will not be available on the returned Monitor objects in all the other repository methods.  That also explains this - https://github.com/racker/salus-telemetry-monitor-management/blob/87a42ca00215a3ee4480444f1e5c80ff294bf1a5/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java#L478

Most of the `MetadataPolicy` fields could still potentially change, but as that class is needed for the aforementioned MonitorMgmt PR, I'm pushing them up as is for now.
They could change once I make more progress on the next task.
