### PR TITLE
Add monitorType to Monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -83,6 +83,11 @@ public class Monitor implements Serializable {
     String content;
 
     @NotNull
+    @Column(name="monitor_type")
+    @Enumerated(EnumType.STRING)
+    MonitorType monitorType;
+
+    @NotNull
     @Column(name="agent_type")
     @Enumerated(EnumType.STRING)
     AgentType agentType;

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.entities;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+public enum MonitorType {
+  ping,
+  http_response,
+  net_response,
+  x509_cert,
+  cpu,
+  disk,
+  diskio,
+  mem,
+  net,
+  procstat
+}

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
@@ -26,6 +26,7 @@ import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -419,6 +420,7 @@ public class BoundMonitorRepositoryTest {
         .setSelectorScope(selectorScope)
         .setContent("{}")
         .setTenantId(monitorTenant)
+        .setMonitorType(MonitorType.http_response)
     );
   }
 }


### PR DESCRIPTION
# What

Adds a `monitorType` field to the `Monitor` entity.

# How

Pulled `MonitorType` out of https://github.com/racker/salus-telemetry-model/pull/71

It is populated with the same values that are found in the name fields of the plugins.  An incoming monitor management PR will tie the two together.

# Why

For Policy Mgmt we will want to query metadata by monitor type.  Having this as a field on the monitor makes life a lot easier.  Otherwise we'd have to parse the string `content` field.
