### PR TITLE
Invert MetadataField to be NonMetadataField

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -19,8 +19,8 @@ package com.rackspace.salus.telemetry.entities;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
-import com.rackspace.salus.telemetry.model.MetadataField;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.NonMetadataField;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
@@ -68,6 +68,7 @@ public class Monitor implements Serializable {
 
     @Id
     @GeneratedValue
+    @NonMetadataField
     @org.hibernate.annotations.Type(type="uuid-char")
     UUID id;
 
@@ -76,64 +77,74 @@ public class Monitor implements Serializable {
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="monitor_label_selectors", joinColumns = @JoinColumn(name="monitor_id"))
+    @NonMetadataField
     Map<String,String> labelSelector;
 
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name="label_selector_method")
+    @NonMetadataField
     LabelSelectorMethod labelSelectorMethod = LabelSelectorMethod.AND;
 
     @NotBlank
     @Column(name="tenant_id")
+    @NonMetadataField
     String tenantId;
 
     @NotBlank
     @Column(length=1000)
+    @NonMetadataField
     String content;
 
     @NotNull
     @Column(name="monitor_type")
     @Enumerated(EnumType.STRING)
+    @NonMetadataField
     MonitorType monitorType;
 
     @NotNull
     @Column(name="agent_type")
     @Enumerated(EnumType.STRING)
+    @NonMetadataField
     AgentType agentType;
 
     @Column(name="selector_scope")
     @Enumerated(EnumType.STRING)
+    @NonMetadataField
     ConfigSelectorScope selectorScope;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="monitor_id"))
-    @MetadataField
     List<String> zones;
 
     @Column(name="resource_id")
+    @NonMetadataField
     String resourceId;
 
     @ElementCollection
     @CollectionTable(name="monitor_metadata_fields", joinColumns = @JoinColumn(name="monitor_id"),
         indexes = @Index(name = "monitors_by_metadata_field", columnList = "monitor_id"))
+    @NonMetadataField
     List<String> monitorMetadataFields;
 
     @ElementCollection
     @CollectionTable(name="plugin_metadata_fields", joinColumns = @JoinColumn(name="monitor_id"),
         indexes = @Index(name = "monitors_by_plugin_metadata_field", columnList = "monitor_id"))
+    @NonMetadataField
     List<String> pluginMetadataFields;
 
     @NotNull
     @Column(name = "monitoring_interval") // just "interval" conflicts with SQL identifiers
-    @MetadataField
     Duration interval;
 
     @CreationTimestamp
     @Column(name="created_timestamp")
+    @NonMetadataField
     Instant createdTimestamp;
 
     @UpdateTimestamp
     @Column(name="updated_timestamp")
+    @NonMetadataField
     Instant updatedTimestamp;
 
     @Override

--- a/src/main/java/com/rackspace/salus/telemetry/model/NonMetadataField.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/NonMetadataField.java
@@ -22,9 +22,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation helps identify which fields can be replaced by default policy metadata values.
+ * This annotation helps identify which fields cannot be replaced by default policy metadata values.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface MetadataField {
+public @interface NonMetadataField {
 }


### PR DESCRIPTION
Rather than setting `@MetadataField` on almost all of our fields, we are going to do the reverse and only set `@NonMetadataField` on fields that we know will never be replaced by metadata.

This doesn't really relate to the monitors defined in monitor management, but does affect the high level Monitor class.