### PR TITLE
Add model changes to the AgentInstall to have a LabelSelectorMethod

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
@@ -37,6 +37,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -77,6 +78,7 @@ public class AgentInstall {
   @NotNull
   @Enumerated(EnumType.STRING)
   @Column(name="label_selector_method")
+  @ColumnDefault("AND")
   LabelSelectorMethod labelSelectorMethod = LabelSelectorMethod.AND;
 
   @CreationTimestamp

--- a/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
@@ -78,7 +78,7 @@ public class AgentInstall {
   @NotNull
   @Enumerated(EnumType.STRING)
   @Column(name="label_selector_method")
-  @ColumnDefault("AND")
+  @ColumnDefault("\'AND\'")
   LabelSelectorMethod labelSelectorMethod = LabelSelectorMethod.AND;
 
   @CreationTimestamp

--- a/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/AgentInstall.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.entities;
 
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -23,6 +24,8 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -32,6 +35,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -69,6 +73,11 @@ public class AgentInstall {
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name="agent_install_label_selectors", joinColumns = @JoinColumn(name="agent_install_id"))
   Map<String,String> labelSelector;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name="label_selector_method")
+  LabelSelectorMethod labelSelectorMethod = LabelSelectorMethod.AND;
 
   @CreationTimestamp
   @Column(name="created_timestamp")


### PR DESCRIPTION
# Resolves

JIRA-606

# What

Add the LabelSelectorMethod to the AgentInstall storage model

## How to test

Compile this and agent-catalog management on my branch over there then create a new AgentInstall object.

# Why

This was how we stored the same information on Monitors
