### PR TITLE
aded ORACLE as an agent type and the new monitor types

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/AgentType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/AgentType.java
@@ -20,5 +20,6 @@ package com.rackspace.salus.telemetry.model;
 
 public enum AgentType {
     TELEGRAF,
-    FILEBEAT
+    FILEBEAT,
+    ORACLE
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -32,7 +32,7 @@ public enum MonitorType {
   sqlserver,
   log,
   system,
-  tablespace,
-  dataguard,
-  rman
+  oracle_tablespace,
+  oracle_dataguard,
+  oracle_rman
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -31,5 +31,8 @@ public enum MonitorType {
   postgresql,
   sqlserver,
   log,
-  system
+  system,
+  tablespace,
+  dataguard,
+  rman
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-693

# What

Adds the Oracle Agent and new oracle agent monitor types

# How

It follows our paradigm for adding new monitors to MonitorType and adding the Oracle Agent to AgentType

## How to test

Run the unit tests in the branch named the same thing in MonitorManagement

