### PR TITLE
Add monitor lookup where no labels or resource id set

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -41,6 +41,16 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     List<Monitor> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
+    /**
+     * Returns any monitor with an empty labelSelector for the given tenant.
+     *
+     * An empty labelSelector is classed as null within sql due to being stored as an
+     * ElementCollection. They are retrieved using a LEFT OUTER JOIN.
+     *
+     * @param tenantId The tenant to get monitors for.
+     * @param page The page of results to return.
+     * @return A page of monitors.
+     */
     Page<Monitor> findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull(String tenantId, Pageable page);
 
     @Query("select m from Monitor m join fetch m.monitorMetadataFields where m.tenantId = :tenantId "

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -41,6 +41,8 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     List<Monitor> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
+    Page<Monitor> findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull(String tenantId, Pageable page);
+
     @Query("select m from Monitor m join fetch m.monitorMetadataFields where m.tenantId = :tenantId "
         + "and :variable member of m.monitorMetadataFields")
     Set<Monitor> findByTenantIdAndMonitorMetadataFieldsContaining(String tenantId, String variable);


### PR DESCRIPTION
Used in https://github.com/racker/salus-telemetry-monitor-management/pull/111

The new repository method `findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull` converts to:

```sql
 SELECT monitor0_.id                    AS id1_13_,
       monitor0_.agent_type            AS agent_ty2_13_,
       monitor0_.content               AS content3_13_,
       monitor0_.created_timestamp     AS created_4_13_,
       monitor0_.monitoring_interval   AS monitori5_13_,
       monitor0_.label_selector_method AS label_se6_13_,
       monitor0_.monitor_name          AS monitor_7_13_,
       monitor0_.monitor_type          AS monitor_8_13_,
       monitor0_.resource_id           AS resource9_13_,
       monitor0_.selector_scope        AS selecto10_13_,
       monitor0_.tenant_id             AS tenant_11_13_,
       monitor0_.updated_timestamp     AS updated12_13_
FROM   monitors monitor0_
       LEFT OUTER JOIN monitor_label_selectors labelselec1_
                    ON monitor0_.id = labelselec1_.monitor_id
WHERE  monitor0_.tenant_id = ?
       AND ( monitor0_.resource_id IS NULL )
       AND ( labelselec1_.label_selector IS NULL )  
```