### PR TITLE
Add dns monitor type

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -24,6 +24,7 @@ public enum MonitorType {
   cpu,
   disk,
   diskio,
+  dns,
   mem,
   net,
   procstat,


### PR DESCRIPTION
Goes with https://github.com/racker/salus-telemetry-monitor-management/pull/115