### PR TITLE
Add monitor translation description field

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
@@ -51,6 +51,9 @@ public class MonitorTranslationOperator {
   @Column(nullable = false, unique = true)
   String name;
 
+  @Column(name = "description")
+  String description;
+
   @Column(name = "agent_type", nullable = false)
   @Enumerated(EnumType.STRING)
   AgentType agentType;

--- a/src/main/resources/db/migration/common/V1_3__add_translator_description.sql
+++ b/src/main/resources/db/migration/common/V1_3__add_translator_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE monitor_translation_operators ADD description VARCHAR(255);


### PR DESCRIPTION
When creating a translation json I wanted to add a note stating why the translation was required/important.