### PR TITLE
Rename monitor types to something more user friendly

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -18,9 +18,9 @@ package com.rackspace.salus.telemetry.model;
 
 public enum MonitorType {
   ping,
-  http_response,
+  http,
   net_response,
-  x509_cert,
+  ssl,
   cpu,
   disk,
   diskio,

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
@@ -419,7 +419,7 @@ public class BoundMonitorRepositoryTest {
         .setSelectorScope(selectorScope)
         .setContent("{}")
         .setTenantId(monitorTenant)
-        .setMonitorType(MonitorType.http_response)
+        .setMonitorType(MonitorType.http)
         .setInterval(Duration.ofSeconds(60))
     );
   }


### PR DESCRIPTION
This allows the user to input `http` or `ssl` as the monitor type and it will be converted by [monitor translations](https://github.com/Rackspace-Segment-Support/salus-data-loader-content/pull/1) to the string expected by telegraf.