### PR TITLE
Add translator to rename monitor type values

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @JsonTypeInfo(use = Id.NAME, property = MonitorTranslator.TYPE_PROPERTY)
 @JsonSubTypes({
     @Type(name = "joinHostPort", value = JoinHostPortTranslator.class),
+    @Type(name = "renameType", value = RenameTypeTranslator.class),
     @Type(name = "renameFieldKey", value = RenameFieldKeyTranslator.class),
     @Type(name = "replaceStringFieldValue", value = ReplaceStringFieldValueTranslator.class),
     @Type(name = "replaceIntFieldValue", value = ReplaceIntFieldValueTranslator.class),

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.translators;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Replaces a field with the new value.
+ * If the field didn't already exist it will be added.
+ */
+@Data @EqualsAndHashCode(callSuper = false)
+public class RenameTypeTranslator extends MonitorTranslator {
+
+  private static final String MONITOR_TYPE_FIELD = "type";
+
+  @NotEmpty
+  String value;
+
+  @Override
+  public void translate(ObjectNode contentTree) {
+    contentTree.put(MONITOR_TYPE_FIELD, value);
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
@@ -22,7 +22,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
- * Replaces a field with the new value.
+ * Replaced the monitor type with the new value provided.
  * If the field didn't already exist it will be added.
  */
 @Data @EqualsAndHashCode(callSuper = false)


### PR DESCRIPTION
Similar to the `replaceStringFieldValue` one but to improve readability since this use-case is not unique.  Discussed here - https://github.com/Rackspace-Segment-Support/salus-data-loader-content/pull/1#discussion_r362013705