### PR TITLE
Update monitor translators

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/errors/MonitorContentTranslationException.java
+++ b/src/main/java/com/rackspace/salus/telemetry/errors/MonitorContentTranslationException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.errors;
+
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.translators.MonitorTranslator;
+
+/**
+ * Indicates that an issue was encountered with either a {@link MonitorTranslator} or the
+ * {@link BoundMonitor}'s rendered content that prevented translation.
+ */
+public class MonitorContentTranslationException extends Exception {
+
+  public MonitorContentTranslationException(String message) {
+    super(message);
+  }
+
+  public MonitorContentTranslationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.translators;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
 import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -40,16 +41,18 @@ public class JoinHostPortTranslator extends MonitorTranslator {
   String to;
 
   @Override
-  public void translate(ObjectNode contentTree) {
+  public void translate(ObjectNode contentTree) throws MonitorContentTranslationException {
     final JsonNode hostNode = contentTree.get(fromHost);
     final JsonNode portNode = contentTree.get(fromPort);
 
-    if (hostNode != null && portNode != null) {
-      // only remove when both present
-      contentTree.remove(fromHost);
-      contentTree.remove(fromPort);
-
-      contentTree.put(to, String.join(":", hostNode.asText(), portNode.asText()));
+    if (hostNode == null || portNode == null) {
+      throw new MonitorContentTranslationException(
+          "Both host and port must be set to use JoinHostPortTranslator");
     }
+    // only remove when both present
+    contentTree.remove(fromHost);
+    contentTree.remove(fromPort);
+
+    contentTree.put(to, String.join(":", hostNode.asText(), portNode.asText()));
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
 
 /**
  * This abstract class is a base class for implementations of monitor content translators. Each
@@ -55,6 +56,6 @@ public abstract class MonitorTranslator {
    *
    * @param contentTree can be manipulated in place, if this translator finds it is applicable
    */
-  public abstract void translate(ObjectNode contentTree);
+  public abstract void translate(ObjectNode contentTree) throws MonitorContentTranslationException;
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.translators;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
 import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -28,13 +29,15 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = false)
 public class RenameTypeTranslator extends MonitorTranslator {
 
-  private static final String MONITOR_TYPE_FIELD = "type";
-
   @NotEmpty
   String value;
 
   @Override
-  public void translate(ObjectNode contentTree) {
-    contentTree.put(MONITOR_TYPE_FIELD, value);
+  public void translate(ObjectNode contentTree) throws MonitorContentTranslationException {
+    if (!contentTree.has(MonitorTranslator.TYPE_PROPERTY)) {
+      throw new MonitorContentTranslationException(
+          "Cannot set type on monitor that has no existing type.");
+    }
+    contentTree.put(MonitorTranslator.TYPE_PROPERTY, value);
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslatorTest.java
@@ -17,9 +17,11 @@
 package com.rackspace.salus.telemetry.translators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -27,7 +29,7 @@ public class JoinHostPortTranslatorTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  public void testTranslate_numericPort() throws IOException {
+  public void testTranslate_numericPort() throws IOException, MonitorContentTranslationException {
     final String content = "{\"host\":\"somewhere\",\"port\":80}";
 
     final ObjectNode contentTree = (ObjectNode) objectMapper.readTree(content);
@@ -45,7 +47,7 @@ public class JoinHostPortTranslatorTest {
   }
 
   @Test
-  public void testTranslate_stringPort() throws IOException {
+  public void testTranslate_stringPort() throws IOException, MonitorContentTranslationException {
     final String content = "{\"host\":\"somewhere\",\"port\":\"80\"}";
 
     final ObjectNode contentTree = (ObjectNode) objectMapper.readTree(content);
@@ -73,12 +75,9 @@ public class JoinHostPortTranslatorTest {
         .setFromHost("host")
         .setFromPort("port")
         .setTo("address");
-    translator.translate(contentTree);
 
-    assertThat(contentTree).hasSize(1);
-
-    // confirm that it leaves the host field as is
-    assertThat(contentTree.get("host")).isNotNull();
-    assertThat(contentTree.get("host").asText()).isEqualTo("somewhere");
+    assertThatThrownBy(() -> translator.translate(contentTree))
+        .isInstanceOf(MonitorContentTranslationException.class)
+        .hasMessage("Both host and port must be set to use JoinHostPortTranslator");
   }
 }


### PR DESCRIPTION
# What

* Moves `MonitorContentTranslationException` from MonMgmt to here.
* Throw `MonitorContentTranslationException` if a problem occurs in the `translate` method.
* Update tests.

# Why

Throwing exceptions allows it to be caught and logged in the monitor translator service.  A metric will also be sent which we can monitor to ensure things are working as expected.