### PR TITLE
Add apache monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitorType.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.model;
 
 public enum MonitorType {
+  apache,
   ping,
   http,
   net_response,


### PR DESCRIPTION
Adds the apache monitor type that will be tied to https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache