### PR TITLE
Add duration translators & improve null handling

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/translators/GoDurationTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/GoDurationTranslator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.translators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Duration;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * It will convert the provided field from a Java Duration to the format expected
+ * by Go.  For example, "PT20S" will be converted to "20s".
+ * If the value is null, no action will be taken.
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GoDurationTranslator extends MonitorTranslator {
+  @NotEmpty
+  String field;
+
+  @Override
+  public void translate(ObjectNode contentTree) {
+
+    if (contentTree.hasNonNull(field)) {
+      final JsonNode node = contentTree.remove(field);
+      String nodes = node.asText();
+      Duration duration = Duration.parse(nodes);
+      if (duration.toSecondsPart() == 0) {
+        contentTree.put(field, String.format("%dm", duration.toMinutes()));
+      } else {
+        contentTree.put(field, String.format("%ds", duration.toSeconds()));
+      }
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
@@ -45,14 +45,15 @@ public class JoinHostPortTranslator extends MonitorTranslator {
     final JsonNode hostNode = contentTree.get(fromHost);
     final JsonNode portNode = contentTree.get(fromPort);
 
-    if (hostNode == null || portNode == null) {
+    if (contentTree.hasNonNull(fromHost) && contentTree.hasNonNull(fromPort)) {
+      // only remove when both present
+      contentTree.remove(fromHost);
+      contentTree.remove(fromPort);
+
+      contentTree.put(to, String.join(":", hostNode.asText(), portNode.asText()));
+    } else {
       throw new MonitorContentTranslationException(
           "Both host and port must be set to use JoinHostPortTranslator");
     }
-    // only remove when both present
-    contentTree.remove(fromHost);
-    contentTree.remove(fromPort);
-
-    contentTree.put(to, String.join(":", hostNode.asText(), portNode.asText()));
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
@@ -40,6 +40,7 @@ import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
  */
 @JsonTypeInfo(use = Id.NAME, property = MonitorTranslator.TYPE_PROPERTY)
 @JsonSubTypes({
+    @Type(name = "goDuration", value = GoDurationTranslator.class),
     @Type(name = "joinHostPort", value = JoinHostPortTranslator.class),
     @Type(name = "renameType", value = RenameTypeTranslator.class),
     @Type(name = "renameFieldKey", value = RenameFieldKeyTranslator.class),

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslator.java
@@ -37,9 +37,15 @@ public class RenameFieldKeyTranslator extends MonitorTranslator {
   @Override
   public void translate(ObjectNode contentTree) {
 
-    final JsonNode node = contentTree.remove(from);
-    if (node != null) {
+
+    if (contentTree.hasNonNull(from)) {
+      final JsonNode node = contentTree.remove(from);
       contentTree.set(to, node);
+    } else {
+      // if a null value is set we still remove the node since it does not have a valid key
+      contentTree.remove(from);
+      // and set a null node
+      contentTree.putNull(to);
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslator.java
@@ -39,10 +39,14 @@ public class ScalarToArrayTranslator extends MonitorTranslator {
 
   @Override
   public void translate(ObjectNode contentTree) {
-    final JsonNode node = contentTree.remove(from);
-
-    if (node != null) {
+    if (contentTree.hasNonNull(from)) {
+      final JsonNode node = contentTree.remove(from);
       contentTree.putArray(to).add(node);
+    } else {
+      // if a null value is set we still remove the node since it does not have a valid key
+      contentTree.remove(from);
+      // and set an empty array node
+      contentTree.putArray(to);
     }
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/translators/GoDurationTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/GoDurationTranslatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.translators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class GoDurationTranslatorTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testTranslate_seconds() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT30S"
+    );
+
+    final GoDurationTranslator translator = new GoDurationTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("30s");
+  }
+
+  @Test
+  public void testTranslate_mins() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT3M"
+    );
+
+    final GoDurationTranslator translator = new GoDurationTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("3m");
+  }
+
+  @Test
+  public void testTranslate_mins_and_secs() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT1M30S"
+    );
+
+    final GoDurationTranslator translator = new GoDurationTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("90s");
+  }
+
+  @Test
+  public void testTranslate_null() throws IOException {
+    // We cannot use a map to test null due to https://github.com/FasterXML/jackson-databind/issues/2430
+    String content = "{\"timeout\": null}";
+
+    final GoDurationTranslator translator = new GoDurationTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = (ObjectNode) objectMapper.readTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+    assertThat(contentTree.get("timeout")).isNotNull();
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslatorTest.java
@@ -19,7 +19,9 @@ package com.rackspace.salus.telemetry.translators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -67,9 +69,32 @@ public class RenameFieldKeyTranslatorTest {
 
     translator.translate(contentTree);
 
-    assertThat(contentTree).hasSize(1);
+    assertThat(contentTree).hasSize(2);
 
     assertThat(contentTree.get("field-not-match")).isNotNull();
     assertThat(contentTree.get("field-not-match").asText()).isEqualTo("value-not-match");
+    assertThat(contentTree.get("field-match")).isNull();
+    assertThat(contentTree.get("new-field")).isNotNull();
+    assertThat(contentTree.get("new-field")).isInstanceOf(NullNode.class);
+  }
+
+  @Test
+  public void testTranslate_null() {
+    final Map<String,String> content = new HashMap<>();
+    content.put("field-match", null);
+
+    final RenameFieldKeyTranslator translator = new RenameFieldKeyTranslator()
+        .setFrom("field-match")
+        .setTo("new-field");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("field-not-match")).isNull();
+    assertThat(contentTree.get("new-field")).isNotNull();
+    assertThat(contentTree.get("new-field")).isInstanceOf(NullNode.class);
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslatorTest.java
@@ -19,7 +19,9 @@ package com.rackspace.salus.telemetry.translators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.util.Map;
 import org.junit.Test;
 
@@ -68,9 +70,30 @@ public class ScalarToArrayTranslatorTest {
 
     translator.translate(contentTree);
 
-    assertThat(contentTree).hasSize(1);
+    assertThat(contentTree).hasSize(2);
 
     assertThat(contentTree.get("field-not-match")).isNotNull();
     assertThat(contentTree.get("field-not-match").asText()).isEqualTo("value-not-match");
+    assertThat(contentTree.get("now-an-array")).hasSize(0);
+  }
+
+  @Test
+  public void testTranslate_nullValue() throws IOException {
+    // We cannot use a map to test null due to https://github.com/FasterXML/jackson-databind/issues/2430
+    String content = "{\"field-match\": null}";
+
+    final ObjectNode contentTree = (ObjectNode) objectMapper.readTree(content);
+
+    final ScalarToArrayTranslator translator = new ScalarToArrayTranslator()
+        .setFrom("field-match")
+        .setTo("now-an-array");
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+    assertThat(contentTree.get("field-match")).isNull();
+    assertThat(contentTree.get("now-an-array")).isNotNull();
+    assertThat(contentTree.get("now-an-array")).isInstanceOf(ArrayNode.class);
+    assertThat(contentTree.get("now-an-array")).hasSize(0);
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-753

# What

1. Adds a translation to convert duration strings to the format expected by go/telegraf plugins
1. Fixes the handling of `null` in the other translators.

# How

1. If the value can be displayed in minutes use that, otherwise convert it to seconds.
1. `hasNonNull` is a more accurate way of testing of null values
    * For cases where we are replacing one key with another I have also set it to remove the original key if it is null and create a new NullNode or empty ArrayNode entry under the `to` key.

## How to test

Added some new null tests.

Due to the differences between `null` and `NullNode` we can not convert a Map to an ObjectNode in these and instead have to convert the raw json string.

# Why

1. We need to be able to translate to the Go format for numerous telegraf plugins.
1. It is also due to `null`/`NullNode` that it's better to use `hasNonNull`.

# TODO

Individual translator content still needs to be added to data loader.