### PR TITLE
Add duration in seconds translator

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslator.java
@@ -24,13 +24,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
- * It will convert the provided field from a Java Duration to the format expected
- * by Go.  For example, "PT20S" will be converted to "20s".
+ * It will convert the provided field from a Java Duration to a long value of raw seconds.
+ * For example, "PT20S" will be converted to "20".
  * If the value is null, no action will be taken.
  */
 @Data
 @EqualsAndHashCode(callSuper = false)
-public class GoDurationTranslator extends MonitorTranslator {
+public class DurationInSecondsTranslator extends MonitorTranslator {
   @NotEmpty
   String field;
 
@@ -40,11 +40,7 @@ public class GoDurationTranslator extends MonitorTranslator {
     if (contentTree.hasNonNull(field)) {
       final JsonNode node = contentTree.remove(field);
       Duration duration = Duration.parse(node.asText());
-      if (duration.toSecondsPart() == 0) {
-        contentTree.put(field, String.format("%dm", duration.toMinutes()));
-      } else {
-        contentTree.put(field, String.format("%ds", duration.toSeconds()));
-      }
+      contentTree.put(field, duration.toSeconds());
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
@@ -40,6 +40,7 @@ import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
  */
 @JsonTypeInfo(use = Id.NAME, property = MonitorTranslator.TYPE_PROPERTY)
 @JsonSubTypes({
+    @Type(name = "durationInSeconds", value = DurationInSecondsTranslator.class),
     @Type(name = "goDuration", value = GoDurationTranslator.class),
     @Type(name = "joinHostPort", value = JoinHostPortTranslator.class),
     @Type(name = "renameType", value = RenameTypeTranslator.class),

--- a/src/test/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslatorTest.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.translators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Map;
@@ -99,5 +100,6 @@ public class DurationInSecondsTranslatorTest {
 
     assertThat(contentTree).hasSize(1);
     assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout")).isInstanceOf(NullNode.class);
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslatorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.translators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.Test;
+
+public class DurationInSecondsTranslatorTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testTranslate_seconds() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT30S"
+    );
+
+    final DurationInSecondsTranslator translator = new DurationInSecondsTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("30");
+  }
+
+  @Test
+  public void testTranslate_mins() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT3M"
+    );
+
+    final DurationInSecondsTranslator translator = new DurationInSecondsTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("180");
+  }
+
+  @Test
+  public void testTranslate_mins_and_secs() {
+    final Map<String,String> content = Map.of(
+        "timeout", "PT1M30S"
+    );
+
+    final DurationInSecondsTranslator translator = new DurationInSecondsTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = objectMapper.valueToTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+
+    assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout").asText()).isEqualTo("90");
+  }
+
+  @Test
+  public void testTranslate_null() throws IOException {
+    // We cannot use a map to test null due to https://github.com/FasterXML/jackson-databind/issues/2430
+    String content = "{\"timeout\": null}";
+
+    final DurationInSecondsTranslator translator = new DurationInSecondsTranslator()
+        .setField("timeout");
+
+    final ObjectNode contentTree = (ObjectNode) objectMapper.readTree(content);
+
+    translator.translate(contentTree);
+
+    assertThat(contentTree).hasSize(1);
+    assertThat(contentTree.get("timeout")).isNotNull();
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/translators/GoDurationTranslatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/translators/GoDurationTranslatorTest.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.translators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.HashMap;
@@ -100,5 +101,6 @@ public class GoDurationTranslatorTest {
 
     assertThat(contentTree).hasSize(1);
     assertThat(contentTree.get("timeout")).isNotNull();
+    assertThat(contentTree.get("timeout")).isInstanceOf(NullNode.class);
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-753

# What

1. Adds a translation to convert duration strings to a raw seconds value.
1. Tiny GoDurationTranslator.java tweak
    * It was accidentally left after I wanted to set a breakpoint on that field.

# How

Simply use the `toSeconds` method.

## How to test

Run tests.

# Why

Plugins such as Ping need their values to be in seconds.

# TODO

Individual translator content still needs to be added to data loader.