### PR TITLE
Add extra operators to kapacitor tasks

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
@@ -85,17 +85,25 @@ public class EventEngineTaskParameters {
 
   public enum Comparator  {
 
+    EQUAL_TO,
+    NOT_EQUAL_TO,
     GREATER_THAN,
     GREATER_THAN_OR_EQUAL_TO,
     LESS_THAN,
-    LESS_THAN_OR_EQUAL_TO;
+    LESS_THAN_OR_EQUAL_TO,
+    REGEX_MATCH,
+    NOT_REGEX_MATCH;
 
     static private HashMap<String, Comparator> convertString = new HashMap<>();
     static {
-        convertString.put(">", GREATER_THAN);
-        convertString.put("<", LESS_THAN);
-        convertString.put(">=", GREATER_THAN_OR_EQUAL_TO);
-        convertString.put("<=", LESS_THAN_OR_EQUAL_TO);
+      convertString.put("==", EQUAL_TO);
+      convertString.put("!=", NOT_EQUAL_TO);
+      convertString.put(">", GREATER_THAN);
+      convertString.put("<", LESS_THAN);
+      convertString.put(">=", GREATER_THAN_OR_EQUAL_TO);
+      convertString.put("<=", LESS_THAN_OR_EQUAL_TO);
+      convertString.put("=~", REGEX_MATCH);
+      convertString.put("!~", NOT_REGEX_MATCH);
     }
     static public boolean valid(String c) {
         return (convertString.get(c) != null);

--- a/src/main/java/com/rackspace/salus/telemetry/validators/ExpressionValidator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/validators/ExpressionValidator.java
@@ -29,7 +29,8 @@ public class ExpressionValidator implements ConstraintValidator<ComparatorValida
   @Constraint(validatedBy = ExpressionValidator.class) // validator
   @Documented
   public @interface ComparatorValidation {
-    String message() default "Valid comparators are: >, >=, <, <="; // default error message
+    String message() default "Valid comparators are: "
+        + "==, !=, >, >=, <, <=, =~, !~"; // default error message
 
     Class<?>[] groups() default {}; // required
 


### PR DESCRIPTION
# What

Adds the ability to use more of kapacitors operators in tasks.

![image](https://user-images.githubusercontent.com/4358210/73282415-38716e80-41b7-11ea-944f-a5e997526c2a.png)


# How

Updates and enum and goes with https://github.com/racker/salus-event-engine-management/pull/33

## How to test

Added some more tests and verified manually that kapacitor accepts the new payload.

# Why

I was looking through the event engine and saw this was an easy thing to add in. It's especially useful for string metrics or integers that don't change much.