### PR TITLE
Add boolean metadata type

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MetadataValueType.java
@@ -17,8 +17,9 @@
 package com.rackspace.salus.telemetry.model;
 
 public enum MetadataValueType {
+  BOOL,
   DURATION,
+  INT,
   STRING,
   STRING_LIST,
-  INT
 }


### PR DESCRIPTION
This allows us to use boolean metadata values, such as for `followRedirects` in an http monitor.