### PR TITLE
added respository function for querying against agent installs with null labels

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/AgentInstallRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/AgentInstallRepository.java
@@ -30,5 +30,7 @@ public interface AgentInstallRepository extends CrudRepository<AgentInstall, UUI
 
   Page<AgentInstall> findAllByTenantId(String tenantId, Pageable pageable);
 
+  List<AgentInstall> findByTenantIdAndLabelSelectorIsNull(String tenantId);
+
   List<AgentInstall> findAllByTenantIdAndAgentRelease_Id(String tenantId, UUID agentReleaseId);
 }


### PR DESCRIPTION

# Resolves

https://jira.rax.io/browse/SALUS-737

# What

Make sure that agent-catalogue-management is doing the same thing as monitor and resource management when an empty set of labels is provided. So we needed to add this function to the interface.

# How

Leverage JPA interface naming conventions to create the concrete implementation for us.

## How to test

Run the agent-catalogue-management tests

# Why

Because this is the simplest way to add this functionality 

# TODO

This should be done