### PR TITLE
Renamed consecutiveCount to stateDuration

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
@@ -56,7 +56,7 @@ public class EventEngineTaskParameters {
 
     @Valid
     Expression expression;
-    Integer consecutiveCount = 1;
+    Integer stateDuration = 1;
   }
 
   @Data

--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
@@ -56,7 +56,7 @@ public class EventEngineTaskParameters {
 
     @Valid
     Expression expression;
-    Integer consecutiveCount;
+    Integer consecutiveCount = 1;
   }
 
   @Data

--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
@@ -56,7 +56,7 @@ public class EventEngineTaskParameters {
 
     @Valid
     Expression expression;
-    Integer stateDuration = 1;
+    Integer stateDuration;
   }
 
   @Data


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-824

# What

Makes sure that even if not provided the user still has a consecutive count

# How

It sets the value in the LevelExpression

## How to test

Run the unit tests

# Why

This seemed like the best way to have the value go through the same validations as everything else the user would input.