### PR TITLE
Add order to translations

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.telemetry.entities;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -92,6 +91,6 @@ public class MonitorTranslationOperator {
    * A translation with an order of 1 will occur before one with an order of 2.
    * If the field is not set it will be treated as 0.
    */
-  @Column(name = "order")
+  @Column(name = "priority_order")
   int order;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorTranslationOperator.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.entities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -84,4 +85,13 @@ public class MonitorTranslationOperator {
   @Column(name = "translator_spec", nullable = false, length = 500)
   @Type(type = "json")
   MonitorTranslator translatorSpec;
+
+  /**
+   * Optional field
+   * If set, it will be used to determine the order the translations on a monitor are performed in.
+   * A translation with an order of 1 will occur before one with an order of 2.
+   * If the field is not set it will be treated as 0.
+   */
+  @Column(name = "order")
+  int order;
 }

--- a/src/main/resources/db/migration/common/V4_1__add_translator_order.sql
+++ b/src/main/resources/db/migration/common/V4_1__add_translator_order.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE monitor_translation_operators ADD priority_order int;

--- a/src/test/java/com/rackspace/salus/telemetry/entities/JsonClobTypeTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/entities/JsonClobTypeTest.java
@@ -58,7 +58,8 @@ public class JsonClobTypeTest {
         .setTranslatorSpec(new RenameFieldKeyTranslator()
             .setFrom("from-field")
             .setTo("to-field")
-        );
+        )
+        .setOrder(0);
 
     final MonitorTranslationOperator saved =
         entityManager.persistFlushFind(operator);


### PR DESCRIPTION
# What

Adds an `order` field to monitor tanslations.

# How

Add one new field.

## How to test

Tests in monitor management

# Why

Now for each monitor that requires translations to be applied in a certain order, we can add a value to each translation to determine what order they are performed in.

> Assuming we have a translation that looks for `timeout` and appends an `s` to the end of the value...
>
> If this value is provided via the api `timeout: 2` and the end result in telegraf needs to be `responseTimeout: 2s`, if the key was renamed before the value had the `s` appended the value translation would currently fail because `timeout` could not be found.

> Another more complex scenario - these three translators get called and need to be done in this order:
>
> JoinHostPortTranslator
> ScalarToArrayTranslator
> RenameTypeTranslator

# TODO

Update data-content-loader payloads.