### PR TITLE
Support the use of monitoring zone policies

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MetadataPolicy.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.telemetry.entities;
 
 import com.rackspace.salus.telemetry.model.MetadataValueType;
-import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.TargetClassName;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -34,6 +33,9 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class MetadataPolicy extends Policy {
+
+  public static final String ZONE_METADATA_PREFIX = "monitoring_zone_";
+  public static final String DEFAULT_ZONE = "default";
 
   @NotNull
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -61,7 +61,10 @@ import org.hibernate.validator.constraints.NotBlank;
             + "where :metadataKey member of m.monitorMetadataFields"),
     @NamedQuery(name = "Monitor.getTenantsUsingPolicyMetadataInPlugin",
         query = "select distinct m.tenantId from Monitor m join m.pluginMetadataFields "
-            + "where :metadataKey member of m.pluginMetadataFields")
+            + "where :metadataKey member of m.pluginMetadataFields"),
+    @NamedQuery(name = "Monitor.getTenantsUsingZoneMetadata",
+        query = "select distinct m.tenantId from Monitor m left outer join m.zones as z where "
+            + "m.selectorScope = 'REMOTE' and z.size = 0")
 })
 @Data
 public class Monitor implements Serializable {

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -116,6 +116,7 @@ public class Monitor implements Serializable {
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="monitor_id"))
+    @NonMetadataField // technically metadata can be used but not in the same way as others
     List<String> zones;
 
     @Column(name="resource_id")

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -24,6 +24,7 @@ import com.rackspace.salus.telemetry.model.NonMetadataField;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,7 +118,7 @@ public class Monitor implements Serializable {
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="monitor_zones", joinColumns = @JoinColumn(name="monitor_id"))
     @NonMetadataField // technically metadata can be used but not in the same way as others
-    List<String> zones;
+    List<String> zones = new ArrayList<>();
 
     @Column(name="resource_id")
     @NonMetadataField

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.entities;
 import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -61,6 +62,8 @@ import org.hibernate.validator.constraints.NotBlank;
 })
 @Data
 public class Resource implements Serializable {
+    public static final String REGION_METADATA = "region";
+
     @Id
     @GeneratedValue
     Long id;
@@ -93,7 +96,7 @@ public class Resource implements Serializable {
      * Unlike labels, metadata is not indexed and not used for resource/monitor matching.
      */
     @Type(type = "json")
-    Map<String,String> metadata;
+    Map<String,String> metadata = new HashMap<>();
 
     @NotBlank
     @Column(name="tenant_id")

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -105,4 +105,5 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
   List<BoundMonitor> findAllByMonitor_IdAndResourceIdIn(UUID monitorId, Collection<String> resourceIds);
 
   List<BoundMonitor> findAllByMonitor_IdAndZoneNameIn(UUID monitorId, Collection<String> zoneNames);
+  List<BoundMonitor> findAllByMonitor_IdAndResourceIdAndZoneNameIn(UUID monitorId, String resourceId, Collection<String> zoneNames);
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorMetadataPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorMetadataPolicyRepository.java
@@ -16,11 +16,11 @@
 
 package com.rackspace.salus.telemetry.repositories;
 
-import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.model.TargetClassName;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
@@ -28,5 +28,8 @@ public interface MonitorMetadataPolicyRepository extends PagingAndSortingReposit
 
   boolean existsByScopeAndSubscopeAndTargetClassNameAndMonitorTypeAndKey(
       PolicyScope policyScope, String subscope, TargetClassName className, MonitorType type, String key);
+
+  Optional<MonitorMetadataPolicy> findByScopeAndTargetClassNameAndKey(PolicyScope policyScope, TargetClassName className, String key);
+
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +46,7 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     Page<Monitor> findByTenantIdAndPolicyIdIsNotNull(String tenantId, Pageable pageable);
     List<Monitor> findByTenantIdAndPolicyIdIsNotNull(String tenantId);
+    Set<Monitor> findByTenantIdAndSelectorScopeAndZonesIsNull(String tenantId, ConfigSelectorScope scope);
 
     /**
      * Returns any monitor with an empty labelSelector for the given tenant.

--- a/src/test/java/com/rackspace/salus/telemetry/entities/Monitor_NamedQueryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/entities/Monitor_NamedQueryTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.entities;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.telemetry.EnableSalusJpa;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import javax.persistence.EntityManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
+@DataJpaTest(showSql = false)
+public class Monitor_NamedQueryTest {
+
+  @Configuration
+  @EnableSalusJpa
+  static class TestConfiguration {
+  }
+
+  @Autowired
+  MonitorRepository monitorRepository;
+
+  @Autowired
+  EntityManager entityManager;
+
+  final int tenantsMonitorMetadata1 = new Random().nextInt(10) + 2;
+  final int tenantsMonitorMetadata2 = new Random().nextInt(10) + 2;
+  final int tenantsPluginMetadata1 = new Random().nextInt(10) + 2;
+  final int tenantsPluginMetadata2 = new Random().nextInt(10) + 2;
+  final int tenantsPolicyZone = new Random().nextInt(10) + 2;
+  final int tenantsLocal = new Random().nextInt(10) + 2;
+
+  @Before
+  public void setup() {
+    // populate tenants using monitor metadata
+    saveMonitorsForTenantWithMetadata(tenantsMonitorMetadata1, List.of("monitorKey1"), Collections.emptyList());
+    saveMonitorsForTenantWithMetadata(tenantsMonitorMetadata2, List.of("monitorKey2"), Collections.emptyList());
+    // populate tenants using plugin metadata
+    saveMonitorsForTenantWithMetadata(tenantsPluginMetadata1, Collections.emptyList(), List.of("pluginKey1"));
+    saveMonitorsForTenantWithMetadata(tenantsPluginMetadata2, Collections.emptyList(), List.of("pluginKey2"));
+    // populate tenants using monitor metadata
+    saveMonitorsForTenantsWithZoneMetadata(tenantsPolicyZone);
+    // populate tenants using local monitors
+    saveLocalMonitors(tenantsLocal);
+  }
+
+  @Test
+  public void testGetTenantsUsingPolicyMetadataInMonitor() {
+    List<String> tenantsUsingPolicyKey = entityManager
+        .createNamedQuery("Monitor.getTenantsUsingPolicyMetadataInMonitor", String.class)
+        .setParameter("metadataKey", "monitorKey1")
+        .getResultList();
+
+    assertThat(tenantsUsingPolicyKey).hasSize(tenantsMonitorMetadata1);
+  }
+
+  @Test
+  public void testGetTenantsUsingPolicyMetadataInPlugin() {
+    List<String> tenantsUsingPolicyKey = entityManager
+        .createNamedQuery("Monitor.getTenantsUsingPolicyMetadataInPlugin", String.class)
+        .setParameter("metadataKey", "pluginKey1")
+        .getResultList();
+
+    assertThat(tenantsUsingPolicyKey).hasSize(tenantsPluginMetadata1);
+  }
+
+  @Test
+  public void testGetTenantsUsingZoneMetadata() {
+    List<String> tenantsUsingZonePolicy = entityManager
+        .createNamedQuery("Monitor.getTenantsUsingZoneMetadata", String.class)
+        .getResultList();
+
+    assertThat(tenantsUsingZonePolicy).hasSize(tenantsPolicyZone);
+  }
+
+  @Test
+  public void testGetTenantsUsingZoneMetadata_moreTenants() {
+    // add more tenants and verify the result is still accurate
+    saveMonitorsForTenantsWithZoneMetadata(5);
+
+    List<String> tenantsUsingZonePolicy = entityManager
+        .createNamedQuery("Monitor.getTenantsUsingZoneMetadata", String.class)
+        .getResultList();
+
+    assertThat(tenantsUsingZonePolicy).hasSize(tenantsPolicyZone + 5);
+  }
+
+  private void saveMonitorsForTenantWithMetadata(int tenants, List<String> monitorMetadata, List<String> pluginMetadata) {
+    // create a random number of monitors per tenant (at least 2)
+    int monitorsPerTenant = new Random().nextInt(10) + 2;
+
+    for (int i = 0; i < tenants; i++) {
+      String tenantId = randomAlphanumeric(5);
+      for (int j = 0; j < monitorsPerTenant; j++) {
+        monitorRepository.save(new Monitor()
+            .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
+            .setContent("original content")
+            .setTenantId(tenantId)
+            .setSelectorScope(ConfigSelectorScope.REMOTE)
+            .setZones(Collections.singletonList("z-1"))
+            .setLabelSelector(Collections.singletonMap("os", "linux"))
+            .setLabelSelectorMethod(LabelSelectorMethod.OR)
+            .setInterval(Duration.ofSeconds(60))
+            .setMonitorMetadataFields(monitorMetadata)
+            .setPluginMetadataFields(pluginMetadata));
+      }
+    }
+  }
+
+  private void saveMonitorsForTenantsWithZoneMetadata(int tenants) {
+    // create a random number of monitors per tenant (at least 2)
+    int monitorsPerTenant = new Random().nextInt(10) + 2;
+
+    for (int i = 0; i < tenants; i++) {
+      String tenantId = randomAlphanumeric(5);
+      for (int j = 0; j < monitorsPerTenant; j++) {
+        monitorRepository.save(new Monitor()
+            .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
+            .setContent("original content")
+            .setTenantId(tenantId)
+            .setSelectorScope(ConfigSelectorScope.REMOTE)
+            .setZones(Collections.emptyList())
+            .setLabelSelector(Collections.singletonMap("os", "linux"))
+            .setLabelSelectorMethod(LabelSelectorMethod.OR)
+            .setInterval(Duration.ofSeconds(60))
+            .setMonitorMetadataFields(Collections.emptyList())
+            .setPluginMetadataFields(Collections.emptyList()));
+      }
+    }
+  }
+
+  private void saveLocalMonitors(int tenants) {
+    // create a random number of monitors per tenant (at least 2)
+    int monitorsPerTenant = new Random().nextInt(10) + 2;
+
+    for (int i = 0; i < tenants; i++) {
+      String tenantId = randomAlphanumeric(5);
+      for (int j = 0; j < monitorsPerTenant; j++) {
+        monitorRepository.save(new Monitor()
+            .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.cpu)
+            .setContent("original content")
+            .setTenantId(tenantId)
+            .setSelectorScope(ConfigSelectorScope.LOCAL)
+            .setZones(Collections.emptyList())
+            .setLabelSelector(Collections.singletonMap("os", "linux"))
+            .setLabelSelectorMethod(LabelSelectorMethod.OR)
+            .setInterval(Duration.ofSeconds(60))
+            .setMonitorMetadataFields(Collections.emptyList())
+            .setPluginMetadataFields(Collections.emptyList()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some changes to help support the ability to use monitoring zone metadata policies.

I've set zones and metadata to default to empty collections so we don't have to worry about null exceptions everywhere.

Relates to:
https://github.com/racker/salus-telemetry-monitor-management/pull/164
https://github.com/racker/salus-policy-management/pull/31
