### PR TITLE
Add tenant verification handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,26 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/rackspace/salus/telemetry/config/RepositoryCacheConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/config/RepositoryCacheConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.config;
+
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RepositoryCacheProperties.class)
+@EnableCaching
+public class RepositoryCacheConfig {
+
+  private final RepositoryCacheProperties properties;
+
+  @Autowired
+  public RepositoryCacheConfig(RepositoryCacheProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public JCacheManagerCustomizer repositoryCacheCustomizer() {
+    return cacheManager -> {
+      cacheManager.createCache("tenant_ids", tenantCacheConfig());
+    };
+  }
+
+  private javax.cache.configuration.Configuration<Object, Object> tenantCacheConfig() {
+    return Eh107Configuration.fromEhcacheCacheConfiguration(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
+            ResourcePoolsBuilder.heap(properties.getTenantSize())
+        )
+            .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/config/RepositoryCacheProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/config/RepositoryCacheProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+@Data
+@ConfigurationProperties("salus.repository.cache")
+public class RepositoryCacheProperties {
+  /**
+   * Maximum cache size of policy references.
+   */
+  long tenantSize = 10_000;
+  /**
+   * Duration to expire cache entries after creation.
+   */
+  @DurationUnit(ChronoUnit.MINUTES)
+  Duration ttl = Duration.ofMinutes(5);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
@@ -25,7 +25,9 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface TenantMetadataRepository extends PagingAndSortingRepository<TenantMetadata, UUID> {
   Optional<TenantMetadata> findByTenantId(String tenantId);
 
-  @Cacheable(cacheNames = "tenant_ids", key = "#tenantId")
+  @Cacheable(cacheNames = "tenant_ids", key = "#tenantId",
+      // avoid caching tenants that don't exist yet
+      unless = "#result == false")
   boolean existsByTenantId(String tenantId);
 }
 

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
@@ -19,9 +19,13 @@ package com.rackspace.salus.telemetry.repositories;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface TenantMetadataRepository extends PagingAndSortingRepository<TenantMetadata, UUID> {
   Optional<TenantMetadata> findByTenantId(String tenantId);
+
+  @Cacheable(cacheNames = "tenant_ids", key = "#tenantId")
+  boolean existsByTenantId(String tenantId);
 }
 

--- a/src/main/java/com/rackspace/salus/telemetry/web/EnableTenantVerification.java
+++ b/src/main/java/com/rackspace/salus/telemetry/web/EnableTenantVerification.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.web;
+
+import com.rackspace.salus.telemetry.config.RepositoryCacheConfig;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import({TenantVerificationWebConfig.class, RepositoryCacheConfig.class})
+public @interface EnableTenantVerification {
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/web/TenantVerification.java
+++ b/src/main/java/com/rackspace/salus/telemetry/web/TenantVerification.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.web;
+
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+public class TenantVerification extends HandlerInterceptorAdapter {
+
+  public static final String ERROR_MSG = "Tenant must be created before any operations can be performed on it";
+
+  public static final String HEADER_TENANT = "X-Tenant-Id";
+  TenantMetadataRepository tenantMetadataRepository;
+
+  public TenantVerification(TenantMetadataRepository repository) {
+    super();
+    this.tenantMetadataRepository = repository;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) throws Exception {
+    String tenantId = request.getHeader(HEADER_TENANT);
+    if (tenantId == null) {
+      // cross-service requests will not contain the header.
+      // neither should any request to the admin api.
+      // only requests proxies from the public api will.
+      return true;
+    } else if (tenantMetadataRepository.existsByTenantId(tenantId)) {
+      return true;
+    } else {
+      throw new NotFoundException(ERROR_MSG);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/web/TenantVerification.java
+++ b/src/main/java/com/rackspace/salus/telemetry/web/TenantVerification.java
@@ -24,7 +24,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 public class TenantVerification extends HandlerInterceptorAdapter {
 
-  public static final String ERROR_MSG = "Tenant must be created before any operations can be performed on it";
+  public static final String ERROR_MSG = "Tenant must be created before any operations can be performed with it";
 
   public static final String HEADER_TENANT = "X-Tenant-Id";
   TenantMetadataRepository tenantMetadataRepository;

--- a/src/main/java/com/rackspace/salus/telemetry/web/TenantVerificationWebConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/web/TenantVerificationWebConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.web;
+
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@Slf4j
+public class TenantVerificationWebConfig implements WebMvcConfigurer {
+
+  @Autowired
+  TenantMetadataRepository tenantMetadataRepository;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    log.debug("Enabling Tenant Verification interceptor");
+    registry.addInterceptor(new TenantVerification(tenantMetadataRepository));
+  }
+}


### PR DESCRIPTION
# What

Adds the ability to verify a tenant exists in the database before any API operation can be performed on it.

# How

Any service annotated with `@EnableTenantVerification` will have its API requests pass through `TenantVerification.preHandle` before they are passed on to the appropriate handler.

If the `X-Tenant-Id` header is set and the value cannot be found within the `tenant_metadata` table then a `NotFoundException` is thrown and a 404 will be returned to the user.  If the value is found in the database the request will proceed as normal.

Additionally, the db operation to see if a tenant exists will be cached to limit the number of db lookups required.

## How to test

Manually and with new tests being added to each service that utilizes the logic.

# Why

To ensure policies are being bound to tenants correctly we need to ensure we know what type of account the tenant is prior to any resources/monitors etc. being created.

This will also allow us to use the `tenant_metadata` table to determine what tenants are affected by policy changes - currently we get the distinct list of tenants from the `resources` table.

This change will allow policies to be activated for a tenant prior to them creating any resources.  In other words, the customer and their support team will know what monitoring is in effect on the account prior to their devices going online (it would often be the case that monitoring is configured prior to the device going online so it is actively monitored immediately once it changes to an online status).

# Other Thing

My concern about "breaking" all our Insomnia requests due to the requirement of having the `X-Tenant-Id` in the requests for this to be processed turned out to not be a problem.  Since it is safe to ignore tenant verification if there is not a tenant id header set, our existing insomnia configs will continue to work fine - just like any service-to-service requests would work.

Similar to the role-based views, if you want to test this logic you either have to manually set the required headers or use an environment that utilized repose and identity authentication.
