### PR TITLE
Skip tenant verification for admin api requests

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/web/TenantVerificationWebConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/web/TenantVerificationWebConfig.java
@@ -33,6 +33,7 @@ public class TenantVerificationWebConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     log.debug("Enabling Tenant Verification interceptor");
-    registry.addInterceptor(new TenantVerification(tenantMetadataRepository));
+    registry.addInterceptor(new TenantVerification(tenantMetadataRepository))
+        .excludePathPatterns("/api/admin/**");
   }
 }


### PR DESCRIPTION
Repose is picking the tenantId from the admin token and passing it down to the service in the x-tenant-id header.  This leads to our applications trying to validate the tenant exists in the system before the request can be processed.

Since admin api requests are not performed against an individual tenant we should skip the verification.