### PR TITLE
added new paged query to find list of ids

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
@@ -40,6 +40,5 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
 
   List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
 
-  @Query("from Resource r where r.id in :resourceIds")
-  Page<Resource> findByResourceId(List<Long> resourceIds, Pageable page);
+  Page<Resource> findByResourceIdIn(List<Long> resourceIds, Pageable page);
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/ResourceRepository.java
@@ -19,8 +19,10 @@ package com.rackspace.salus.telemetry.repositories;
 import com.rackspace.salus.telemetry.entities.Resource;
 import java.util.List;
 import java.util.Optional;
+import org.hibernate.annotations.NamedQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 
@@ -37,4 +39,7 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
   Optional<Resource> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
   List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
+
+  @Query("from Resource r where r.id in :resourceIds")
+  Page<Resource> findByResourceId(List<Long> resourceIds, Pageable page);
 }


### PR DESCRIPTION
Connected to https://github.com/racker/salus-telemetry-resource-management/pull/79

This PR makes sure that we are still querying the database for paged content rather than doing paging in the server itself for the list of resourceId's obtained from the label query. 