### PR TITLE
Ensure metadata is not stored as null

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/dbmigrations/V7_1__update_metadata_to_empty_from_null.java
+++ b/src/main/java/com/rackspace/salus/telemetry/dbmigrations/V7_1__update_metadata_to_empty_from_null.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.telemetry.dbmigrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V7_1__update_metadata_to_empty_from_null extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
+    jdbcTemplate.execute("UPDATE resources SET metadata = '{}' WHERE metadata is NULL");
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
@@ -96,6 +96,7 @@ public class Resource implements Serializable {
      * Unlike labels, metadata is not indexed and not used for resource/monitor matching.
      */
     @Type(type = "json")
+    @NotNull
     Map<String,String> metadata = new HashMap<>();
 
     @NotBlank

--- a/src/main/resources/db/migration/h2/V7_0__change_resource_metadata.sql
+++ b/src/main/resources/db/migration/h2/V7_0__change_resource_metadata.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table resources
+    alter column metadata
+    longtext not null;

--- a/src/main/resources/db/migration/mysql/V7_0__change_resource_metadata.sql
+++ b/src/main/resources/db/migration/mysql/V7_0__change_resource_metadata.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table resources
+    change column metadata
+        metadata longtext not null;;

--- a/src/main/resources/db/migration/mysql/V7_0__change_resource_metadata.sql
+++ b/src/main/resources/db/migration/mysql/V7_0__change_resource_metadata.sql
@@ -16,4 +16,4 @@
 
 alter table resources
     change column metadata
-        metadata longtext not null;;
+        metadata longtext not null;


### PR DESCRIPTION
Updates resource metadata to be non-null.

I copied the sql migration files from `V3_0__` which shows different queries are needed for h2 vs. mysql.

Also added a java migration file to automatically update the current null values to be an empty list.  I've tested this change locally.