### PR TITLE
Add info to translations

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorPolicyRepository.java
@@ -16,9 +16,8 @@
 
 package com.rackspace.salus.telemetry.repositories;
 
-import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import java.util.Optional;
+import com.rackspace.salus.telemetry.model.PolicyScope;
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
@@ -27,7 +26,4 @@ public interface MonitorPolicyRepository extends PagingAndSortingRepository<Moni
   boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
 
   boolean existsByMonitorId(UUID monitorId);
-
-  Optional<MonitorPolicy> findByMonitorId(UUID monitorId);
-
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorTranslationOperatorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorTranslationOperatorRepository.java
@@ -25,6 +25,8 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface MonitorTranslationOperatorRepository extends
     PagingAndSortingRepository<MonitorTranslationOperator, UUID> {
 
+  List<MonitorTranslationOperator> findAll();
+
   List<MonitorTranslationOperator> findAllByAgentType(AgentType agentType);
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/DurationInSecondsTranslator.java
@@ -43,4 +43,9 @@ public class DurationInSecondsTranslator extends MonitorTranslator {
       contentTree.put(field, duration.toSeconds());
     }
   }
+
+  @Override
+  public String info() {
+    return String.format("'%s' becomes a number of seconds", field);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/GoDurationTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/GoDurationTranslator.java
@@ -47,4 +47,9 @@ public class GoDurationTranslator extends MonitorTranslator {
       }
     }
   }
+
+  @Override
+  public String info() {
+    return String.format("'%s' becomes a Golang formatted duration", field);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/JoinHostPortTranslator.java
@@ -56,4 +56,10 @@ public class JoinHostPortTranslator extends MonitorTranslator {
           "Both host and port must be set to use JoinHostPortTranslator");
     }
   }
+
+  @Override
+  public String info() {
+    return String.format("The value of '%s' and '%s' are combined into '%s:%s' and named '%s'",
+        fromHost, fromPort, fromHost, fromPort, to);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/MonitorTranslator.java
@@ -60,4 +60,6 @@ public abstract class MonitorTranslator {
    */
   public abstract void translate(ObjectNode contentTree) throws MonitorContentTranslationException;
 
+  public abstract String info();
+
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameFieldKeyTranslator.java
@@ -48,4 +48,9 @@ public class RenameFieldKeyTranslator extends MonitorTranslator {
       contentTree.putNull(to);
     }
   }
+
+  @Override
+  public String info() {
+    return String.format("The key '%s' is renamed to '%s'", from, to);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/RenameTypeTranslator.java
@@ -40,4 +40,9 @@ public class RenameTypeTranslator extends MonitorTranslator {
     }
     contentTree.put(MonitorTranslator.TYPE_PROPERTY, value);
   }
+
+  @Override
+  public String info() {
+    return String.format("The monitor's type is renamed to '%s'", value);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/ReplaceIntFieldValueTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/ReplaceIntFieldValueTranslator.java
@@ -39,4 +39,9 @@ public class ReplaceIntFieldValueTranslator extends MonitorTranslator {
   public void translate(ObjectNode contentTree) {
     contentTree.put(field, value);
   }
+
+  @Override
+  public String info() {
+    return String.format("The value of '%s' is set to %d", field, value);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/ReplaceStringFieldValueTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/ReplaceStringFieldValueTranslator.java
@@ -38,4 +38,9 @@ public class ReplaceStringFieldValueTranslator extends MonitorTranslator {
   public void translate(ObjectNode contentTree) {
     contentTree.put(field, value);
   }
+
+  @Override
+  public String info() {
+    return String.format("The value of '%s' is set to '%s'", field, value);
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/translators/ScalarToArrayTranslator.java
@@ -49,4 +49,13 @@ public class ScalarToArrayTranslator extends MonitorTranslator {
       contentTree.putArray(to);
     }
   }
+
+  @Override
+  public String info() {
+    if (from.equals(to)) {
+      return String.format("'%s' becomes a singleton array", from);
+    } else {
+      return String.format("'%s' becomes the singleton array named '%s'", from, to);
+    }
+  }
 }


### PR DESCRIPTION
When thinking about the Monitors documentation I decided we needed an endpoint to expose a "friendly" description of what all the translators are.

We can include that list i the documentation but reference the API endpoint as the best place to get the up to date info.

To achieve this I've updated all the translators to have a new `info` method.

Related PR: https://github.com/racker/salus-telemetry-monitor-management/pull/180