### PR TITLE
Allow policies to have a null monitorId

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
@@ -35,7 +34,6 @@ public class MonitorPolicy extends Policy {
   @Column(name="name")
   String name;
 
-  @NotNull
   @Column(name="monitor_id")
   @org.hibernate.annotations.Type(type="uuid-char")
   UUID monitorId;

--- a/src/main/resources/db/migration/mysql/V8_0__allow_null_policy_monitors.sql
+++ b/src/main/resources/db/migration/mysql/V8_0__allow_null_policy_monitors.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table monitor_policies
+    change column monitor_id
+        monitor_id varchar(255) null;


### PR DESCRIPTION
Opting out of a monitor policy simply means creating a `Tenant` scoped policy that has the correct name and a `null` `monitorId` set.

To achieve that the db/entity has to allow for null values.

This is related to:

https://github.com/racker/salus-policy-management/pull/37/files
https://github.com/racker/salus-telemetry-monitor-management/pull/182
https://github.com/racker/salus-telemetry-api/pull/86