### PR TITLE
Get all tenants from tenant db instead of resource db

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Resource.java
@@ -56,9 +56,7 @@ import org.hibernate.validator.constraints.NotBlank;
     @NamedQuery(name = "Resource.getDistinctLabels",
     query = "select distinct entry(r.labels) from Resource r where r.tenantId = :tenantId"),
     @NamedQuery(name = "Resource.getMetadata",
-    query = "select r.metadata from Resource r where r.tenantId = :tenantId"),
-    @NamedQuery(name = "Resource.getAllDistinctTenants",
-    query = "select distinct r.tenantId from Resource r")
+    query = "select r.metadata from Resource r where r.tenantId = :tenantId")
 })
 @Data
 public class Resource implements Serializable {

--- a/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/TenantMetadata.java
@@ -41,7 +41,9 @@ import org.hibernate.validator.constraints.NotBlank;
 })
 @NamedQueries({
     @NamedQuery(name = "TenantMetadata.getByAccountType",
-        query = "select distinct t.tenantId from TenantMetadata t where t.accountType = :accountType")
+        query = "select distinct t.tenantId from TenantMetadata t where t.accountType = :accountType"),
+    @NamedQuery(name = "TenantMetadata.getAllDistinctTenants",
+        query = "select distinct t.tenantId from TenantMetadata t")
 })
 @Data
 public class TenantMetadata {

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/TenantMetadataRepository.java
@@ -30,4 +30,3 @@ public interface TenantMetadataRepository extends PagingAndSortingRepository<Ten
       unless = "#result == false")
   boolean existsByTenantId(String tenantId);
 }
-


### PR DESCRIPTION
# Fixes

https://jira.rax.io/browse/SALUS-872

# What

Rather than relying on the Resources table to determine what tenants exist, this instead pulls the info from the tenant-metadata table.

This means when a new monitor policy is created it can impact a tenant that exists in the system but does not yet have any resources.

i.e. the policy monitor will be cloned to that tenant but there will not yet be any bound monitors due to no resources existing.