### PR TITLE
Allow values other than int to be set for a task threshold

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java
@@ -62,7 +62,6 @@ public class EventEngineTaskParameters {
   @Data
   @EvalExpressionValidation
   public static class EvalExpression {
-
     @NotEmpty
     List<String> operands;
     @NotBlank
@@ -76,11 +75,19 @@ public class EventEngineTaskParameters {
     @NotEmpty
     String field;
     @NotNull
-    Number threshold;
+    Object threshold;
     @NotEmpty
     @ExpressionValidator.ComparatorValidation()
     String comparator;
 
+    /**
+     * A method used within tests to help podam know how to populate the threshold field.
+     * Otherwise it does not know what to insert for an 'Object'.
+     * @param value A random string value to be used as the threshold.
+     */
+    public void podamHelper(String value) {
+      this.threshold = value;
+    }
   }
 
   public enum Comparator  {


### PR DESCRIPTION
# What

Goes with https://github.com/racker/salus-event-engine-management/pull/47.

Allows thresholds to be set to values other than Number, e.g. Strings.

No SQL changes are needed since this value gets stored as json

```
  @Type(type = "json")
  @Column(nullable = false)
  EventEngineTaskParameters taskParameters;
```