### PR TITLE
added findMonitorsBoundToResourceAndTenant to BoundMonitorRepository

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -108,4 +108,9 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findAllByMonitor_IdAndZoneNameIn(UUID monitorId, Collection<String> zoneNames);
   List<BoundMonitor> findAllByMonitor_IdAndResourceIdAndZoneNameIn(UUID monitorId, String resourceId, Collection<String> zoneNames);
+
+  @Query("select b from BoundMonitor b"
+      + " where b.resourceId = :resourceId"
+      + " and b.monitor.tenantId = :tenantId")
+  List<BoundMonitor> findMonitorsBoundToResourceAndTenant(String tenantId, String resourceId);
 }

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -71,7 +71,7 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
   @Query("select distinct b.monitor.id from BoundMonitor b"
       + " where b.resourceId = :resourceId"
       + " and b.monitor.tenantId = :tenantId")
-  List<UUID> findMonitorsBoundToResource(String tenantId, String resourceId);
+  List<UUID> findMonitorIdsBoundToTenantAndResource(String tenantId, String resourceId);
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -73,6 +73,11 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
       + " and b.monitor.tenantId = :tenantId")
   List<UUID> findMonitorIdsBoundToTenantAndResource(String tenantId, String resourceId);
 
+  @Query("select b from BoundMonitor b"
+      + " where b.resourceId = :resourceId"
+      + " and b.monitor.tenantId = :tenantId")
+  List<BoundMonitor> findMonitorsBoundToTenantAndResource(String tenantId, String resourceId);
+
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 
   Page<BoundMonitor> findAllByMonitor_IdAndMonitor_TenantId(UUID monitorId, String tenantId, Pageable page);
@@ -108,9 +113,4 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findAllByMonitor_IdAndZoneNameIn(UUID monitorId, Collection<String> zoneNames);
   List<BoundMonitor> findAllByMonitor_IdAndResourceIdAndZoneNameIn(UUID monitorId, String resourceId, Collection<String> zoneNames);
-
-  @Query("select b from BoundMonitor b"
-      + " where b.resourceId = :resourceId"
-      + " and b.monitor.tenantId = :tenantId")
-  List<BoundMonitor> findMonitorsBoundToResourceAndTenant(String tenantId, String resourceId);
 }

--- a/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepositoryTest.java
@@ -356,7 +356,7 @@ public class BoundMonitorRepositoryTest {
     }
 
     final List<UUID> monitorIds = repository
-        .findMonitorsBoundToResource("t-0", "r-1");
+        .findMonitorIdsBoundToTenantAndResource("t-0", "r-1");
 
     assertThat(monitorIds, hasSize(5));
 


### PR DESCRIPTION
# Resolves

[SALUS-980](https://jira.rax.io/browse/SALUS-980)

# What

Resolved - Deleting resource also deletes bound monitors for other resources.