### PR TITLE
added Set of monitorId to JPA query.

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -75,8 +75,9 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   @Query("select b from BoundMonitor b"
       + " where b.resourceId = :resourceId"
-      + " and b.monitor.tenantId = :tenantId")
-  List<BoundMonitor> findMonitorsBoundToTenantAndResource(String tenantId, String resourceId);
+      + " and b.monitor.tenantId = :tenantId"
+      + " and b.monitor.id IN :monitorIdsToUnbind")
+  List<BoundMonitor> findMonitorsBoundToTenantAndResourceAndMonitor_IdIn(String tenantId, String resourceId, Set<UUID> monitorIdsToUnbind);
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 


### PR DESCRIPTION
# Resolves

[SALUS-980](https://jira.rax.io/browse/SALUS-980)

# What

Resolved - Deleting resource also deletes bound monitors for other resources.

# Depends on

https://github.com/racker/salus-telemetry-monitor-management/pull/195