### PR TITLE
Setup Spring JPA Envers audit logging for monitors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
+  ~
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -98,7 +99,16 @@
       <version>0.1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-envers</artifactId>
+      <version>5.4.21.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-envers</artifactId>
+      <version>2.3.3.RELEASE</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/rackspace/salus/telemetry/EnableSalusJpa.java
+++ b/src/main/java/com/rackspace/salus/telemetry/EnableSalusJpa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.rackspace.salus.telemetry;
@@ -24,14 +25,17 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Configuration
 @EntityScan("com.rackspace.salus.telemetry.entities")
 @ComponentScan("com.rackspace.salus.telemetry.dbmigrations")
-@EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
+@EnableJpaRepositories(repositoryFactoryBeanClass=EnversRevisionRepositoryFactoryBean.class, value="com.rackspace.salus.telemetry.repositories")//
+@EnableJpaAuditing
 @PropertySource("classpath:spring-flyway.properties")
 public @interface EnableSalusJpa {
 

--- a/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/Monitor.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.rackspace.salus.telemetry.entities;
@@ -33,6 +34,7 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -43,13 +45,23 @@ import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.history.RevisionMetadata;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.envers.Audited;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
+@Audited
 @Table(name = "monitors", indexes = {
     @Index(name = "monitors_by_tenant_and_resource", columnList = "tenant_id, resource_id")
 })
@@ -156,12 +168,26 @@ public class Monitor implements Serializable {
     @CreationTimestamp
     @Column(name="created_timestamp")
     @NonMetadataField
+    @CreatedDate
     Instant createdTimestamp;
 
     @UpdateTimestamp
     @Column(name="updated_timestamp")
     @NonMetadataField
+    @LastModifiedDate
     Instant updatedTimestamp;
+
+    @Column(name = "created_by")
+    @CreatedBy
+    private String createdBy;
+
+    @Column(name = "modified_by")
+    @LastModifiedBy
+    private String modifiedBy;
+
+    @Transient
+    private RevisionMetadata<Integer> editVersion;
+
 
     @Override
     public String toString() {

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/MonitorRepository.java
@@ -29,9 +29,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.history.RevisionRepository;
 import org.springframework.data.repository.query.Param;
 
-public interface MonitorRepository extends PagingAndSortingRepository<Monitor, UUID> {
+public interface MonitorRepository extends RevisionRepository<Monitor, UUID, Integer>, PagingAndSortingRepository<Monitor, UUID> {
 
     boolean existsByIdAndTenantId(UUID id, String tenantId);
 


### PR DESCRIPTION
This PR serves as a basis for how we can setup Spring JPA-Envers style audit logging. This information will be placed in our `docs/proposals` I just wanted a draft PR to reference.

Ultimately this is very simple. You have to tell the base class that it needs to utilize an Envers style factory when instantiating the JPA repositories. 

For each repository we need audited we extend the `RevisionRepository`

We also need to add the `@Audited` annotation with the `@EntityListeners(AuditingEntityListener.class)` annotation to each entity object we want audited. While also adding
```
    @Transient
    private RevisionMetadata<Integer> editVersion;
```
To the class as well. The @CreatedBy annotation shows Spring where to inject the user on create operations. 

Curiously I had set `ddl-auto:true` but accidentally reverted it before I ran this and it still generated the audit tables. 

I do want to point out the fact that the audit table utilizes the same schema as the actual table, and while this is helpful for giving us more granular data that is easier to search through, it also means that when updating the schema of anything in the database the audit table is going to take a long time to update. Part of our data governance strategy should be an understanding of data retention in the audit table and clearing that out. If only to allow us to update the schema more easily. 

# TODO
- [ ] Fix Spring Security to pass through into the microservices so JPA can automatically inject who was doing what.
- [ ] Link to article for injecting not just the authorized user but the impersonation information as well
- [ ] Link to docs showing how to set this up to send data to a different data source
- [ ] Pull the schema information from the audit tables generated by JPA and create flyway migrations out of it