### PR TITLE
Added BoundMonitorProjection class to get large BMs from DB.

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitor.java
@@ -30,7 +30,9 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.validator.constraints.NotBlank;
@@ -96,6 +98,8 @@ indexes = {
 public class BoundMonitor implements Serializable {
 
   @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
   public static class PrimaryKey implements Serializable {
 
     /**

--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitorProjection.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitorProjection.java
@@ -1,0 +1,15 @@
+package com.rackspace.salus.telemetry.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class BoundMonitorProjection {
+
+  String envoyId;
+  Monitor monitor;
+  String tenantId;
+  String zoneName;
+  String resourceId;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitorProjection.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/BoundMonitorProjection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.entities;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/telemetry/repositories/BoundMonitorRepository.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.repositories;
 
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.BoundMonitorProjection;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -94,7 +95,7 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
   List<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant);
   Page<BoundMonitor> findAllByTenantIdAndMonitor_TenantId(String tenantId, String policyTenant, Pageable page);
 
-  List<BoundMonitor> findAllByTenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds);
+  List<BoundMonitorProjection> findAllByTenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds);
   Page<BoundMonitor> findAllByTenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds, Pageable page);
 
   List<BoundMonitor> findAllByMonitor_TenantIdAndMonitor_IdIn(String tenantId, Collection<UUID> monitorIds);


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-1031

# What
Added BoundMonitorProjection class to get large BMs from DB.

# How
Created BoundMonitorProjection class.

# How to test
This can be tested via Rest API.

# Why
This limits the data to what is only required to process bound monitor retrieval.