### PR TITLE
 Add new MonitoringSystem enum 

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTask.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTask.java
@@ -16,10 +16,13 @@
 
 package com.rackspace.salus.telemetry.entities;
 
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import java.time.Instant;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
@@ -51,14 +54,9 @@ public abstract class EventEngineTask {
   @Column
   String name;
 
-  /**
-   * Contains the String representation of
-   * com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem
-   *
-   * The enum is not used directly to avoid adding umb-protocol as a required dependency.
-   */
+  @Enumerated(EnumType.STRING)
   @Column(name = "monitoring_system", nullable = false)
-  String monitoringSystem;
+  MonitoringSystem monitoringSystem;
 
   @NotNull
   @Type(type = "json")

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitoringSystem.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitoringSystem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.model;
+
+/**
+ * A copy of the core values com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem
+ *
+ * This helps reduce the amount of services that depend on umb-protocol.
+ *
+ * It also makes the systems Salus supports clearer and prevents potentially new incompatable
+ * monitoring systems from being automatically included.
+ */
+public enum MonitoringSystem {
+  MAAS,
+  UIM,
+  SALUS,
+  SCOM,
+  ZENOSS,
+  UNRECOGNIZED
+}


### PR DESCRIPTION
Copies the values from the umb-protocol `MonitoringSystem` enum over here. 

In addition to the below details, this allows us to use the enum on the entity class since they are now within the same library.  This will simplify things in a few places as we don't have to switch between enum and string.

```
/**
 * A copy of the core values com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem
 *
 * This helps reduce the amount of services that depend on umb-protocol.
 *
 * It also makes the systems Salus supports clearer and prevents potentially new incompatable
 * monitoring systems from being automatically included.
 */
```