### PR TITLE
Use lowercase enum values in api

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/model/ConfigSelectorScope.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/ConfigSelectorScope.java
@@ -18,7 +18,11 @@
 
 package com.rackspace.salus.telemetry.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum ConfigSelectorScope {
+    @JsonProperty("local")
     LOCAL,
+    @JsonProperty("remote")
     REMOTE
 }

--- a/src/main/java/com/rackspace/salus/telemetry/model/MonitoringSystem.java
+++ b/src/main/java/com/rackspace/salus/telemetry/model/MonitoringSystem.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.telemetry.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * A copy of the core values com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem
  *
@@ -25,10 +27,16 @@ package com.rackspace.salus.telemetry.model;
  * monitoring systems from being automatically included.
  */
 public enum MonitoringSystem {
+  @JsonProperty("maas")
   MAAS,
+  @JsonProperty("uim")
   UIM,
+  @JsonProperty("salus")
   SALUS,
+  @JsonProperty("scom")
   SCOM,
+  @JsonProperty("zenoss")
   ZENOSS,
+  @JsonProperty("unrecognized")
   UNRECOGNIZED
 }


### PR DESCRIPTION
# What

Make enum values lowercase when used in api request bodies or responses.

# How

`@JsonProperty`

# Why

It makes the fields throughout the api more consistent.

e.g. when creating a monitor we set `type: local` due to `@Type(name = "local", value=LocalMonitorDetails.class)`.  Without setting these new `JsonProperty` values we would have to use `mointorScope: LOCAL` in the tasks api.  `local` fails because it cannot be mapped to any available enum.

For monitoring systems it also allows us to alter the value to something more customer facing if we ever need to... or for future name changes like Nimbus->UIM->whatever it is now.  And ele/mass/cloudMonitoring/rackspaceMonitoring.