### PR TITLE
Remove old migration location

### DIFF
--- a/src/main/resources/spring-flyway.properties
+++ b/src/main/resources/spring-flyway.properties
@@ -18,5 +18,5 @@
 # for our embedded H2 in unit testing and MySQL otherwise.
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-execute-flyway-database-migrations-on-startup
 # for a description of vendor placeholder.
-spring.flyway.locations = classpath:db/migration/common,classpath:db/migration/{vendor}
+spring.flyway.locations = classpath:db/migration/{vendor}
 spring.jpa.hibernate.ddl-auto = validate


### PR DESCRIPTION
# What

Resolves this warning:

```
Unable to resolve location classpath:db/migration/common. Note this warning will become an error in Flyway 7.
```