### PR TITLE
Add agent connection history pruning

### DIFF
--- a/src/main/resources/db/migration/mysql/V15_0__prune_old_agent_connections.sql
+++ b/src/main/resources/db/migration/mysql/V15_0__prune_old_agent_connections.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE EVENT IF NOT EXISTS cleaning ON SCHEDULE EVERY 1 DAY ENABLE
+    DO
+    DELETE FROM agent_history
+    WHERE connected_timestamp < CURRENT_TIMESTAMP - INTERVAL 1 MONTH
+      AND disconnected_timestamp IS NOT NULL;

--- a/src/main/resources/db/migration/mysql/V15_0__prune_old_agent_connections.sql
+++ b/src/main/resources/db/migration/mysql/V15_0__prune_old_agent_connections.sql
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-CREATE EVENT IF NOT EXISTS cleaning ON SCHEDULE EVERY 1 DAY ENABLE
+CREATE EVENT IF NOT EXISTS agent_history_cleaning ON SCHEDULE EVERY 1 DAY ENABLE
     DO
     DELETE FROM agent_history
     WHERE connected_timestamp < CURRENT_TIMESTAMP - INTERVAL 1 MONTH


### PR DESCRIPTION
# What

Enabled pruning of agent connection history.

# How

This is the same query described in the original proposal.

Locally this command is also needed on the docker container `--event-scheduler=ON`.  In other environments a google db flag will be set to enable it.

The scheduler cannot be enabled in the migration files due to inadequate permissions.

## How to test

In localdev I set it to a 10s schedule to remove any connections over 2mins and it worked.

# Why

This is needed to clear up any old agent connections that we no longer care about.

# TODO

Bundle PR coming soon.