### PR TITLE
renamed monitor_id to monitor_template_id

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/telemetry/entities/MonitorPolicy.java
@@ -34,7 +34,7 @@ public class MonitorPolicy extends Policy {
   @Column(name="name")
   String name;
 
-  @Column(name="monitor_id")
+  @Column(name="monitor_template_id")
   @org.hibernate.annotations.Type(type="uuid-char")
-  UUID monitorId;
+  UUID monitorTemplateId;
 }

--- a/src/main/resources/db/migration/mysql/V15_0__rename_column_in_monitor_policies.sql
+++ b/src/main/resources/db/migration/mysql/V15_0__rename_column_in_monitor_policies.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,4 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.repositories;
-
-import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import com.rackspace.salus.telemetry.model.PolicyScope;
-import java.util.UUID;
-import org.springframework.data.repository.PagingAndSortingRepository;
-
-public interface MonitorPolicyRepository extends PagingAndSortingRepository<MonitorPolicy, UUID> {
-
-  boolean existsByScopeAndSubscopeAndName(PolicyScope policyScope, String subscope, String name);
-
-  boolean existsByMonitorTemplateId(UUID monitorTemplateId);
-}
+ALTER TABLE monitor_policies CHANGE monitor_id monitor_template_id VARCHAR(255);


### PR DESCRIPTION
# Resolves

[SALUS-1035](https://jira.rax.io/browse/SALUS-1035)

# What

renamed monitor_id to monitor_template_id

# Depends On

https://github.com/racker/salus-policy-management/pull/48